### PR TITLE
Fix python extensions upload

### DIFF
--- a/src/commandPalette/buildExtension.ts
+++ b/src/commandPalette/buildExtension.ts
@@ -34,7 +34,7 @@ export async function buildExtension(
   fastMode?: FastModeOptions
 ) {
   // Basic details we already know exist
-  let workspaceStorage = context.storageUri!.fsPath;
+  const workspaceStorage = context.storageUri!.fsPath;
   const workSpaceConfig = vscode.workspace.getConfiguration("dynatrace", null);
   const devKey = workSpaceConfig.get("developerKeyLocation") as string;
   const devCert = workSpaceConfig.get("developerCertificateLocation") as string;

--- a/src/commandPalette/buildExtension.ts
+++ b/src/commandPalette/buildExtension.ts
@@ -68,7 +68,7 @@ export async function buildExtension(
       const zipFilename = `${extension.name.replace(":", "_")}-${extension.version}.zip`;
       try {
         getDatasourceName(extension) === "python"
-          ? await assemblePython(workspaceRoot, workspaceStorage, devKey, devCert, oc)
+          ? await assemblePython(workspaceStorage, extensionDir, devKey, devCert, oc)
           : assembleStandard(workspaceStorage, extensionDir, zipFilename, devKey, devCert);
       } catch (err: any) {
         vscode.window.showErrorMessage(`Error during archiving & signing: ${err.message}`);
@@ -222,7 +222,7 @@ function runCommand(command: string, oc: vscode.OutputChannel, envOptions?: Exec
  * @param devCertPath the path to the developer's certificate
  * @param oc JSON output channel for communicating errors
  */
-async function assemblePython(extensionDir: string, distDir: string, devKeyPath: string, devCertPath: string, oc: vscode.OutputChannel) {
+async function assemblePython(workspaceStorage: string, extensionDir: string, devKeyPath: string, devCertPath: string, oc: vscode.OutputChannel) {
   let envOptions = {} as ExecOptions;
   const pythonPath = await getPythonPath();
 
@@ -241,7 +241,8 @@ async function assemblePython(extensionDir: string, distDir: string, devKeyPath:
   await runCommand("dt-sdk --help", oc, envOptions); // this will throw if dt-sdk is not available
 
   // Build
-  await runCommand(`dt-sdk build -k "${devKeyPath}" -c "${devCertPath}" "${extensionDir}" -t "${distDir}"`, oc, envOptions);
+  const pythonExtensionDir = path.resolve(extensionDir, "..");
+  await runCommand(`dt-sdk build -k "${devKeyPath}" -c "${devCertPath}" "${pythonExtensionDir}" -t "${workspaceStorage}"`, oc, envOptions);
 }
 
 /**


### PR DESCRIPTION
Python extensions are not built to workspaceStorage, so the upload fails because it can't find the zip file at the workspaceStorage.

The code is getting a bit messy, might want to have a different method that handles python extensions

I don't know how to add a test for this behavior quite yet, will research