### PR TITLE
Better Support for Prometheus Metric's Scraping

### DIFF
--- a/src/codeActions/prometheus.ts
+++ b/src/codeActions/prometheus.ts
@@ -119,17 +119,6 @@ export class PrometheusActionProvider implements vscode.CodeActionProvider {
     var codeActions: vscode.CodeAction[] = [];
     const availableKeys = Object.keys(this.prometheusData).filter((key) => !existingKeys.includes(key));
 
-    // Insert individual metrics
-    availableKeys.forEach((key) => {
-      codeActions.push(
-        this.createInsertAction(
-          `Insert ${key} metric`,
-          `- key: ${key}\n  value: metric:${key}\n  type: ${this.prometheusData[key].type}`,
-          document,
-          range
-        )
-      );
-    });
     // Insert all metrics in one go
     if (availableKeys.length > 1) {
       codeActions.push(
@@ -143,6 +132,18 @@ export class PrometheusActionProvider implements vscode.CodeActionProvider {
         )
       );
     }
+
+    // Insert individual metrics
+    availableKeys.forEach((key) => {
+      codeActions.push(
+        this.createInsertAction(
+          `Insert ${key} metric`,
+          `- key: ${key}\n  value: metric:${key}\n  type: ${this.prometheusData[key].type}`,
+          document,
+          range
+        )
+      );
+    });
 
     return codeActions;
   }


### PR DESCRIPTION
Fixed bug where Prometheus scraping would fail if metric did not have any dimensions.

Also moved "Insert All" metrics to top of Code Actions as this will help with large lists of metrics. 
Another area to improve this is to make the list of CodeActions for inserting metrics scrollable or pageable (if either is possible). Could also implement filtering when setting up URL to only grab/show metrics with specific prefix. 