### PR TITLE
Authority Key Identifier extension not needed for root CA Cert

### DIFF
--- a/src/commandPalette/generateCertificates.ts
+++ b/src/commandPalette/generateCertificates.ts
@@ -22,12 +22,6 @@ export async function generateCerts(context: vscode.ExtensionContext): Promise<b
       progress.report({ message: "Generating RSA key pair for CA certificate" });
       try {
         var caKey = pki.rsa.generateKeyPair({ bits: 4096, e: 0x10001 });
-        var caSKI = pki.getPublicKeyFingerprint(caKey.publicKey, {
-          md: md.sha256.create(),
-          type: "SubjectPublicKeyInfo",
-          encoding: "hex",
-          delimiter: ":",
-        });
       } catch (err: any) {
         vscode.window.showErrorMessage("Error generating the RSA key pair for the CA certificate");
         console.log(err.message);
@@ -68,10 +62,6 @@ export async function generateCerts(context: vscode.ExtensionContext): Promise<b
           },
           {
             name: "subjectKeyIdentifier",
-          },
-          {
-            name: "authorityKeyIdentifier",
-            keyIdentifier: caSKI,
           },
         ]);
         caCert.sign(caKey.privateKey, md.sha256.create());


### PR DESCRIPTION
Based on this link https://github.com/digitalbazaar/forge/issues/265#issuecomment-110094511 the Authority Key Identifier extension not needed for root CA Cert (ca.pem) file. Removing this extension allows the OneAgent and ActiveGate to correctly validate the extension signature for extensions. 

Validated by removing the extension, generating new certs and testing prometheus based extension on both an AG and OA. Both passed signature validation and was able to upload cert/extension to Dynatrace cluster. 