### PR TITLE
Auto generated screens  : add injection cards

### DIFF
--- a/src/codeActions/utils/snippetBuildingUtils.ts
+++ b/src/codeActions/utils/snippetBuildingUtils.ts
@@ -71,7 +71,7 @@ export function buildScreenSnippet(
   snippet = snippet.replace("<self-list-key>", `${slugify(typeDefinition.name)}_list_self`);
   snippet = snippet.replace("<charts-cards>", "\n" + indentSnippet(chartCardsSnippet, indent, false));
   snippet = snippet.replace("<entities-list-cards>", "\n" + indentSnippet(entitiesListCardsSnippet, indent, false));
-  snippet = snippet.replace("<details-layout-cards>", "\n" + indentSnippet(cardKeysSnippet, indent + 8, false));
+  snippet = snippet.replace("<details-layout-cards>", "\n" + indentSnippet(cardKeysSnippet, indent + 6, false));
 
   return indentSnippet(snippet, indent, withNewline);
 }

--- a/src/codeActions/utils/snippets.ts
+++ b/src/codeActions/utils/snippets.ts
@@ -95,6 +95,7 @@ export const screenSnippet = `\
       cards:
         - key: <self-list-key>
           type: ENTITIES_LIST
+        - type: INJECTIONS
   detailsSettings:
     staticContent:
       showProblems: true

--- a/src/codeActions/utils/snippets.ts
+++ b/src/codeActions/utils/snippets.ts
@@ -111,6 +111,7 @@ export const screenSnippet = `\
     layout:
       autoGenerate: false
       cards: <details-layout-cards>
+          - type: INJECTIONS
   chartsCards: <charts-cards>
   entitiesListCards: <entities-list-cards>`;
 

--- a/src/codeActions/utils/snippets.ts
+++ b/src/codeActions/utils/snippets.ts
@@ -112,7 +112,7 @@ export const screenSnippet = `\
     layout:
       autoGenerate: false
       cards: <details-layout-cards>
-          - type: INJECTIONS
+        - type: INJECTIONS
   chartsCards: <charts-cards>
   entitiesListCards: <entities-list-cards>`;
 


### PR DESCRIPTION
Added  `- type: INJECTIONS` to both the listSettings and detailsSettings sections for auto-generated Screens. Tested with SQL DS and 3 entities. Verified it worked with both individual entity as well as add all entities options. 