### PR TITLE
65 wmi code lens does not clear correctly

### DIFF
--- a/src/codeLens/wmiCodeLens.ts
+++ b/src/codeLens/wmiCodeLens.ts
@@ -95,8 +95,18 @@ class WmiQueryResultLens extends vscode.CodeLens {
 export class WmiCodeLensProvider implements vscode.CodeLensProvider {
   private wmiQueryLens: WmiQueryLens[] = [];
   private wmiQueryResultLens: WmiQueryResultLens[] = [];
-  private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
-  public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+
+  // Keep a copy of the old lenses so that we can reuse them if the lines were moved around
+  private previousWMIQueryLens: WmiQueryLens[] = [];
+  private previousWMIQueryResultLens: WmiQueryResultLens[] = [];
+
+  // When we modify lens ourselves, we don't clear the cache
+  private selfUpdateTriggered = false;
+
+  private _onDidChangeCodeLenses: vscode.EventEmitter<void> =
+    new vscode.EventEmitter<void>();
+  public readonly onDidChangeCodeLenses: vscode.Event<void> =
+    this._onDidChangeCodeLenses.event;
   private cachedData: CachedDataProvider;
 
   /**
@@ -110,10 +120,25 @@ export class WmiCodeLensProvider implements vscode.CodeLensProvider {
     document: vscode.TextDocument,
     token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.CodeLens[]> {
+    
+    if (!this.selfUpdateTriggered) {
+      // Clear the lenses, keep a saved copy of the old ones in case lines were moved around
+      // We only do this if the lenses were not updated by us
+      this.previousWMIQueryLens = this.wmiQueryLens;
+      this.wmiQueryLens = [];
+  
+      this.previousWMIQueryResultLens = this.wmiQueryResultLens;
+      this.wmiQueryResultLens = [];
+    }
+    
+    this.selfUpdateTriggered = false;
     const text = document.getText();
 
     // Return early because it is cheaper than parsing the yaml
-    if (!text.includes("wmi:") || !vscode.workspace.getConfiguration("dynatrace", null).get("wmiCodeLens")) {
+    if (
+      !text.includes("wmi:") ||
+      !vscode.workspace.getConfiguration("dynatrace", null).get("wmiCodeLens")
+    ) {
       return [];
     }
 
@@ -135,13 +160,19 @@ export class WmiCodeLensProvider implements vscode.CodeLensProvider {
 
     for (const group of extension.wmi!) {
       if (group.query) {
-        const newLens = this.createLens(group.query, document);
+        const createdEarlier = this.previousWMIQueryLens.find(
+          (lens) => lens.wmiQuery === group.query
+        );
+        this.createLens(group.query, document, createdEarlier);
       }
 
       if (group.subgroups) {
         for (const subgroup of group.subgroups) {
           if (subgroup.query) {
-            this.createLens(subgroup.query, document);
+            const createdEarlier = this.previousWMIQueryLens.find(
+              (lens) => lens.wmiQuery === subgroup.query
+            );
+            this.createLens(subgroup.query, document, createdEarlier);
           }
         }
       }
@@ -153,14 +184,23 @@ export class WmiCodeLensProvider implements vscode.CodeLensProvider {
   /**
    * This receives a WMI query like 'SELECT Name, MessagesinQueue, BytesInQueue FROM Win32_PerfRawData_msmq_MSMQQueue'
    * It finds all the ocurrences of this text on the document and creates a code lens for each one
+   * If there was a code lens created earlier, it will reuse it and move it to the new position
    *
    * @param lineToMatch The line that we want to match
    * @param document the document to search for the query
    */
-  createLens(lineToMatch: string, document: vscode.TextDocument) {
+  createLens(
+    lineToMatch: string,
+    document: vscode.TextDocument,
+    createdEarlier?: WmiQueryLens
+  ) {
     // If this exact query string was already added, return
     // Needed in the rare case the user has the same query more than once
-    if (this.wmiQueryLens.find(lens => (lens as WmiQueryLens).wmiQuery === lineToMatch)) {
+    if (
+      this.wmiQueryLens.find(
+        (lens) => (lens as WmiQueryLens).wmiQuery === lineToMatch
+      )
+    ) {
       return;
     }
     const text = document.getText();
@@ -178,8 +218,27 @@ export class WmiCodeLensProvider implements vscode.CodeLensProvider {
       );
 
       if (range) {
-        this.wmiQueryLens.push(new WmiQueryLens(range, lineToMatch));
-        this.wmiQueryResultLens.push(new WmiQueryResultLens(range, lineToMatch));
+        if (createdEarlier) {
+          // Update the range (this can change if the user moves lines around)
+          createdEarlier.range = range;
+          this.wmiQueryLens.push(createdEarlier);
+
+          // Find the previous result lens and update the range
+          const previousResultLens = this.previousWMIQueryResultLens.find(
+            (lens) => lens.wmiQuery === lineToMatch
+          );
+          if (previousResultLens) { // This is always true
+            previousResultLens.range = range;
+            this.wmiQueryResultLens.push(previousResultLens);
+          }
+
+        } else {
+          // This was not created earlier, create a new lens
+          this.wmiQueryLens.push(new WmiQueryLens(range, lineToMatch));
+          this.wmiQueryResultLens.push(
+            new WmiQueryResultLens(range, lineToMatch)
+          );
+        }
       }
     }
   }
@@ -188,25 +247,27 @@ export class WmiCodeLensProvider implements vscode.CodeLensProvider {
     this.cachedData.addWmiQueryResult(result);
 
     // Find the WmiQueryResultLens that matches this query
-    const ownerLens = this.wmiQueryResultLens.find(
-      lens => (lens as WmiQueryResultLens).wmiQuery === query
-    ) as WmiQueryResultLens;
+    const ownerLens = this.previousWMIQueryResultLens.find(
+        (lens) => lens.wmiQuery === query
+      );
 
     if (ownerLens) {
       ownerLens.updateResult(result);
       WMIQueryResultsPanel.createOrShow(result);
+      this.selfUpdateTriggered = true;
       this._onDidChangeCodeLenses.fire();
     }
   };
 
   setQueryRunning = (query: string) => {
     // Find the WmiQueryResultLens that matches this query
-    const ownerLens = this.wmiQueryResultLens.find(
-      lens => (lens as WmiQueryResultLens).wmiQuery === query
-    ) as WmiQueryResultLens;
+    const ownerLens = this.previousWMIQueryResultLens.find(
+      (lens) => lens.wmiQuery === query
+    );
 
     if (ownerLens) {
       ownerLens.setQueryRunning();
+      this.selfUpdateTriggered = true;
       this._onDidChangeCodeLenses.fire();
     }
   };

--- a/src/codeLens/wmiCodeLens.ts
+++ b/src/codeLens/wmiCodeLens.ts
@@ -130,7 +130,7 @@ export class WmiCodeLensProvider implements vscode.CodeLensProvider {
       this.previousWMIQueryResultLens = this.wmiQueryResultLens;
       this.wmiQueryResultLens = [];
     }
-    
+
     this.selfUpdateTriggered = false;
     const text = document.getText();
 
@@ -188,6 +188,7 @@ export class WmiCodeLensProvider implements vscode.CodeLensProvider {
    *
    * @param lineToMatch The line that we want to match
    * @param document the document to search for the query
+   * @param createdEarlier a code lens that was created earlier, if it exists
    */
   createLens(
     lineToMatch: string,


### PR DESCRIPTION
WMI Code Lens were never cleared or moved around properly.

This addresses the issue by:

1. Clear the current lens when the user updates the document
2. Keep a saved copy of the old lens, in case the user simply moved the lens to another position
3. If the user moved the lens to a new position, reuse the old lens but update the range (to keep results), otherwise create a new one