### PR TITLE
Add Convert JMX Extension command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
 	"name": "dt-ext-copilot",
-	"version": "0.16.0",
+	"version": "1.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dt-ext-copilot",
-			"version": "0.16.0",
+			"version": "1.0.1",
 			"dependencies": {
 				"adm-zip": "^0.5.9",
 				"axios": "^0.27.2",
 				"form-data": "^4.0.0",
 				"glob": "^8.0.3",
+				"jszip": "^3.10.1",
 				"node-forge": "^1.3.1",
 				"open": "^8.4.0",
 				"yaml": "^2.1.1"
@@ -766,8 +767,7 @@
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -1845,6 +1845,11 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -1984,8 +1989,7 @@
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -2017,6 +2021,17 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
+		"node_modules/jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"dependencies": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
+			}
+		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2028,6 +2043,14 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"dependencies": {
+				"immediate": "~3.0.5"
 			}
 		},
 		"node_modules/listenercount": {
@@ -2408,6 +2431,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2480,8 +2508,7 @@
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
@@ -2525,7 +2552,6 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -2539,8 +2565,7 @@
 		"node_modules/readable-stream/node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
@@ -2699,8 +2724,7 @@
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -2736,7 +2760,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -2744,8 +2767,7 @@
 		"node_modules/string_decoder/node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
@@ -2912,8 +2934,7 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"node_modules/v8-compile-cache": {
 			"version": "2.3.0",
@@ -3572,8 +3593,7 @@
 		"core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
@@ -4278,6 +4298,11 @@
 			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 			"dev": true
 		},
+		"immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+		},
 		"import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4372,8 +4397,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -4402,6 +4426,17 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
+		"jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"requires": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
+			}
+		},
 		"levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4410,6 +4445,14 @@
 			"requires": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
+			}
+		},
+		"lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"requires": {
+				"immediate": "~3.0.5"
 			}
 		},
 		"listenercount": {
@@ -4690,6 +4733,11 @@
 				"p-limit": "^3.0.2"
 			}
 		},
+		"pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+		},
 		"parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4738,8 +4786,7 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -4766,7 +4813,6 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -4780,8 +4826,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				}
 			}
 		},
@@ -4879,8 +4924,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -4907,7 +4951,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			},
@@ -4915,8 +4958,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				}
 			}
 		},
@@ -5042,8 +5084,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"email": "extensions@dynatrace.com",
 		"url": "https://info.dynatrace.com/global_all_wp_dynatrace_services_platform_extensions_fact_sheet_13656_fulfillment.html"
 	},
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/dynatrace-extensions/dynatrace-extensions-copilot.git"

--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
 				"category": "Dynatrace"
 			},
 			{
+				"command": "dt-ext-copilot.convertJmxExtension",
+				"title": "Convert JMX Extension",
+				"category": "Dynatrace"
+			},
+			{
 				"command": "dt-ext-copilot-workspaces.refresh",
 				"title": "Refresh",
 				"icon": "$(refresh)"
@@ -784,6 +789,7 @@
 		"axios": "^0.27.2",
 		"form-data": "^4.0.0",
 		"glob": "^8.0.3",
+		"jszip": "^3.10.1",
 		"node-forge": "^1.3.1",
 		"open": "^8.4.0",
 		"yaml": "^2.1.1"

--- a/src/codeActions/prometheus.ts
+++ b/src/codeActions/prometheus.ts
@@ -17,6 +17,8 @@
 import * as vscode from "vscode";
 import { PromData } from "../codeLens/prometheusScraper";
 import { CachedDataProvider } from "../utils/dataCaching";
+import { ExtensionStub } from "../interfaces/extensionMeta";
+
 import {
   getAllMetricKeysAndValuesFromDataSource,
   getPrometheusLabelKeys,

--- a/src/codeActions/snippetGenerator.ts
+++ b/src/codeActions/snippetGenerator.ts
@@ -43,6 +43,7 @@ import {
 } from "./utils/snippetBuildingUtils";
 import { getBlockItemIndexAtLine, getParentBlocks } from "../utils/yamlParsing";
 import { CachedDataProvider } from "../utils/dataCaching";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 
 /**
  * Provider for Code Actions that insert snippets of code into the existing extension yaml.

--- a/src/codeActions/snmp.ts
+++ b/src/codeActions/snmp.ts
@@ -15,6 +15,7 @@
  */
 
 import * as vscode from "vscode";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 import { CachedDataProvider } from "../utils/dataCaching";
 import { getMetricsFromDataSource } from "../utils/extensionParsing";
 import { buildMetricMetadataSnippet, indentSnippet } from "./utils/snippetBuildingUtils";

--- a/src/codeActions/utils/snippetBuildingUtils.ts
+++ b/src/codeActions/utils/snippetBuildingUtils.ts
@@ -33,6 +33,7 @@ import {
   relationSnippet,
   screenSnippet,
 } from "./snippets";
+import { ExtensionStub, TopologyType } from "../../interfaces/extensionMeta";
 
 /**
  * Builds a YAML snippet for an action that sends to extension configuration.

--- a/src/codeCompletions/entitySelectors.ts
+++ b/src/codeCompletions/entitySelectors.ts
@@ -15,6 +15,7 @@
  */
 
 import * as vscode from "vscode";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 import { CachedDataProvider } from "../utils/dataCaching";
 import {
   getAttributesKeysFromTopology,

--- a/src/codeCompletions/prometheus.ts
+++ b/src/codeCompletions/prometheus.ts
@@ -16,6 +16,7 @@
 
 import * as vscode from "vscode";
 import { PromData } from "../codeLens/prometheusScraper";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 import { CachedDataProvider } from "../utils/dataCaching";
 import {
   getDatasourceName,

--- a/src/codeCompletions/screensMeta.ts
+++ b/src/codeCompletions/screensMeta.ts
@@ -15,6 +15,7 @@
  */
 
 import * as vscode from "vscode";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 import { CachedDataProvider } from "../utils/dataCaching";
 import { getReferencedCardsMeta, getDefinedCardsMeta } from "../utils/extensionParsing";
 import { getBlockItemIndexAtLine, getParentBlocks } from "../utils/yamlParsing";

--- a/src/codeCompletions/topology.ts
+++ b/src/codeCompletions/topology.ts
@@ -16,6 +16,7 @@
 
 import * as vscode from "vscode";
 import * as yaml from "yaml";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 import { CachedDataProvider } from "../utils/dataCaching";
 import {
   getAttributesKeysFromTopology,

--- a/src/codeLens/selectorCodeLens.ts
+++ b/src/codeLens/selectorCodeLens.ts
@@ -16,6 +16,7 @@
 
 import * as vscode from "vscode";
 import * as yaml from "yaml";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 import { CachedDataProvider } from "../utils/dataCaching";
 import { resolveSelectorTemplate, ValidationStatus } from "./utils/selectorUtils";
 

--- a/src/codeLens/utils/selectorUtils.ts
+++ b/src/codeLens/utils/selectorUtils.ts
@@ -19,6 +19,7 @@ import { Dynatrace } from "../../dynatrace-api/dynatrace";
 import { DynatraceAPIError } from "../../dynatrace-api/errors";
 import { MetricResultsPanel } from "../../webviews/metricResults";
 import { getBlockItemIndexAtLine, getParentBlocks } from "../../utils/yamlParsing";
+import { ExtensionStub } from "../../interfaces/extensionMeta";
 
 export interface ValidationStatus {
   status: "valid" | "invalid" | "unknown";

--- a/src/commandPalette/convertJMXExtension.ts
+++ b/src/commandPalette/convertJMXExtension.ts
@@ -1,0 +1,278 @@
+/**
+  Copyright 2023 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import * as vscode from "vscode";
+import * as jszip from "jszip";
+import * as yaml from "yaml";
+import { Dynatrace } from "../dynatrace-api/dynatrace";
+import { JMXExtensionV1, JMXExtensionV2, JMXSubGroup, MetricDto, SourceDto } from "../interfaces/extensionMeta";
+import { slugify } from "../codeActions/utils/snippetBuildingUtils";
+
+const OPTION_LOCAL_FILE = "Local (filesystem)";
+const OPTION_DYNATRACE_ENVIRONMENT = "Remote (dynatrace environment)";
+
+export async function convertJMXExtension(context: vscode.ExtensionContext, dt: Dynatrace) {
+
+    // User choses if they want to use a local file or browse from the Dynatrace environment
+    const pluginJSONOrigins = [OPTION_LOCAL_FILE, OPTION_DYNATRACE_ENVIRONMENT];
+    const pluginJSONOrigin = await vscode.window.showQuickPick(pluginJSONOrigins, {
+        placeHolder: "How would you like to import the JMX v1 plugin.json?",
+        title: "Dynatrace: Convert JMX extension",
+    });
+
+    // If the user cancels the operation, return
+    if (!pluginJSONOrigin) {
+        return;
+    }
+
+    let jmxV1Extension = null;
+
+    // If the user chose to use a local file, ask them to select the file
+    if (pluginJSONOrigin === OPTION_LOCAL_FILE) {
+        const options: vscode.OpenDialogOptions = {
+            canSelectMany: false,
+            openLabel: "Select",
+            title: "Select JMX v1 plugin zip or plugin.json file",
+            filters: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                "JMX v1 plugin": ["json", "zip"]              
+            },
+        };
+        const pluginJSONFile = await vscode.window.showOpenDialog(options);
+        if (!pluginJSONFile) {
+            vscode.window.showErrorMessage("No file was selected. Operation cancelled.");
+            return;
+        }
+
+        // If this is a zip file, extract the plugin.json file from it
+        if (pluginJSONFile[0].fsPath.endsWith(".zip")) {
+            const binaryData = await vscode.workspace.fs.readFile(pluginJSONFile[0]);
+            jmxV1Extension = await extractPluginJSONFromZip(binaryData);
+        } else {
+            // If this is a json file, just read it
+            const fileContents = await vscode.workspace.fs.readFile(pluginJSONFile[0]);
+            jmxV1Extension = JSON.parse(fileContents.toString());
+        }
+    }
+
+    // If the user chose to browse from the Dynatrace environment, use the API to list the current extensions
+    if (pluginJSONOrigin === OPTION_DYNATRACE_ENVIRONMENT) {
+        const currentExtensions = await dt.extensionsV1.getExtensions();
+
+        // We only want JMX custom extensions (not the built-in ones)
+        // Dynatrace created extensions cannot be downloaded via the API
+        const currentJMXExtensions = currentExtensions.filter((extension) => extension.type === "JMX" && !extension.id.startsWith("dynatrace."));
+        const jmxExtensionNames = currentJMXExtensions.map((extension) => `${extension.id} | ${extension.name}`);
+        
+        const jmxExtensionName = await vscode.window.showQuickPick(jmxExtensionNames, {
+            placeHolder: "Choose a JMX v1 extension",
+            title: "Dynatrace: Convert JMX extension",
+        });
+        if (!jmxExtensionName) {
+            vscode.window.showErrorMessage("No extension was selected. Operation cancelled.");
+            return;
+        }
+
+        // Get the binary of the extension zip file
+        const jmxExtensionId = jmxExtensionName.split(" | ")[0];
+        const binaryData = await dt.extensionsV1.getExtensionBinary(jmxExtensionId);
+        
+        // Extract the plugin.json file from the zip
+        jmxV1Extension = await extractPluginJSONFromZip(binaryData);        
+    }
+
+    // Convert the JMX v1 extension to v2
+    const jmxV2Extension = convertJMXExtensionToV2(jmxV1Extension);
+
+    // Ask the user where they would like to save the file to
+    const options: vscode.SaveDialogOptions = {
+        saveLabel: "Save",
+        title: "Save JMX v2 extension.yaml",
+        filters: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "JMX v2 extension": ["yaml"]
+        },
+        defaultUri: vscode.Uri.file(`${slugify(jmxV2Extension.name)}.yaml`),
+    };
+    const extensionYAMLFile = await vscode.window.showSaveDialog(options);
+    if (!extensionYAMLFile) {
+        vscode.window.showErrorMessage("No file was selected. Operation cancelled.");
+        return;
+    }
+    // Save the file as yaml
+    const yamlFileContents = yaml.stringify(jmxV2Extension);
+    await vscode.workspace.fs.writeFile(extensionYAMLFile, Buffer.from(yamlFileContents));
+    
+}
+
+
+/**
+ * Get the contents of the plugin.json file from a zip file binary data
+ * @param binaryData The binary data of the zip file
+ * @returns The contents of the plugin.json file
+*/
+async function extractPluginJSONFromZip(binaryData: Buffer | Uint8Array): Promise<JMXExtensionV1> {
+
+    const zip = await jszip.loadAsync(binaryData);
+    
+    // Find the first ocurrence of plugin.json in the files in the zip
+    const pluginJSONFile = Object.keys(zip.files).find((file) => file.endsWith("plugin.json"));
+    if (!pluginJSONFile) {
+        throw new Error("The selected extension does not contain a plugin.json file.");
+    }
+
+    console.log(`Found plugin.json at ${pluginJSONFile}`);
+
+    const pluginJsonFileContent = await zip.file(pluginJSONFile)?.async("string");
+    if (!pluginJsonFileContent) {
+        throw new Error("Could not extract the plugin.json file.");
+    }
+
+    const jmxV1Extension = JSON.parse(pluginJsonFileContent) as JMXExtensionV1;
+    return jmxV1Extension;
+
+}
+
+
+/**
+* Converts a JMX extension v1 to the v2 format
+* @param jmxV1Extension The v1 extension (plugin.json)
+* @returns The converted v2 extension (extension.yaml)
+*/
+function convertJMXExtensionToV2(jmxV1Extension: JMXExtensionV1): JMXExtensionV2 {
+
+    const extensionName = jmxV1Extension.metricGroup || jmxV1Extension.name;
+
+    const jmxV2Extension: JMXExtensionV2 = {
+        name: `custom:${extensionName}`,
+        version: '1.0.0',
+        minDynatraceVersion: '1.265',
+        author: {
+            name: 'Dynatrace'
+        }
+    };
+
+    // First get the metric metadata from the v1 extension
+    jmxV2Extension.metrics = jmxV1Extension.metrics.map(metric => {
+        return {
+            key: metric.timeseries.key,
+            metadata: {
+                displayName: metric.timeseries.displayname,
+                unit: metric.timeseries.unit
+            }
+        };
+    });
+
+    // Populate the subgroups
+    jmxV2Extension.jmx = {
+        groups: [
+        {
+            group: "jmx",
+            subgroups: jmxV1Extension.metrics.map(metric => {
+
+                const extensionDefinition: JMXSubGroup =  {
+                    subgroup: metric.timeseries.key,
+                    query: extractQueryString(metric.source),
+                    // queryFilters: [],
+                    metrics: [{
+                        key: `${extensionName}.${metric.timeseries.key}`,
+                        value: `attribute:${metric.source.attribute}`,
+                        type: metric.source.calculateDelta ? 'count' : 'gauge'
+                    }],
+
+                };
+                const dimensions = extractSplittings(metric).map(splitting => {
+                    return {
+                        key: splitting,
+                        value: `property:${splitting}`
+                    };
+                }) ;
+                if (dimensions.length > 0) {
+                    extensionDefinition.dimensions = dimensions;
+                }
+                return extensionDefinition;
+        
+            })
+        }   
+    ]};
+
+    return jmxV2Extension;
+
+}
+
+/**
+ * Converts a v1 JMX query to the v2 format
+ * Original: {"domain": "java.lang", "keyProperties": {"name": "G1 Eden Space", "type": "MemoryPool"}},
+ * Converted: java.lang:name=G1 Eden Space,type=MemoryPool
+ * @param v1MetricSource The plugin v1 metric 'source' property
+ * @returns The query string
+*/
+function extractQueryString(v1MetricSource: SourceDto): string {
+    if (v1MetricSource.domain === null) {
+        throw new Error('No MBean domain found');
+    }
+
+    // Convert the key properties to a string separated by commas
+    const keyProperties = Object.entries(v1MetricSource.keyProperties).map(([key, value]) => `${key}=${value}`).join(',');
+    const query = `${v1MetricSource.domain}:${keyProperties}`;
+    
+    if (v1MetricSource.allowAdditionalKeys) {
+        return query + ",*";
+    }
+    return query;
+
+}
+
+/**
+ * Converts a v1 JMX splitting (dimensions) to the v2 format
+ * Original: {"name": "ConnectionPool"}
+ * Converted: connection_pool
+ * @param v1Metric The plugin v1 metric object
+ * @returns A list of valid dimension names
+ */
+function extractSplittings(v1Metric: MetricDto): string[] {
+    const splittings: string[] = [];
+    if (v1Metric.source.splitting) {
+        splittings.push(fixDimensionKey(v1Metric.source.splitting.name));
+    }
+    if (v1Metric.source.splittings) {
+        v1Metric.source.splittings.forEach(splitting => {
+            splittings.push(fixDimensionKey(splitting.name));
+        });
+    }
+    return splittings;
+
+}
+
+/*
+Dimension keys cannot have uppercase letters
+We need to convert them to lowercase and add an underscore before the uppercase letters.
+*/
+function fixDimensionKey(name: string): string {
+    let sb = '';
+    for (let i = 0; i < name.length; i++) {
+        const ch = name.charAt(i);
+        if (ch.toUpperCase() === ch) {
+            if (i > 0) {
+                sb += '_';
+            }
+            sb += ch.toLowerCase();
+        } else {
+            sb += ch;
+        }
+    }
+    return sb;
+}

--- a/src/commandPalette/convertJMXExtension.ts
+++ b/src/commandPalette/convertJMXExtension.ts
@@ -115,6 +115,11 @@ export async function convertJMXExtension(context: vscode.ExtensionContext, dt: 
     // Save the file as yaml
     const yamlFileContents = yaml.stringify(jmxV2Extension);
     await vscode.workspace.fs.writeFile(extensionYAMLFile, Buffer.from(yamlFileContents));
+
+    // Open the file
+    const document = await vscode.workspace.openTextDocument(extensionYAMLFile);
+    await vscode.window.showTextDocument(document);
+    
     
 }
 

--- a/src/commandPalette/createAlert.ts
+++ b/src/commandPalette/createAlert.ts
@@ -21,6 +21,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 
 import path = require("path");
 import { getAllMetricKeysFromDataSource } from "../utils/extensionParsing";
 import { CachedDataProvider } from "../utils/dataCaching";
+import { MetricMetadata } from "../interfaces/extensionMeta";
 
 export async function createAlert(cachedData: CachedDataProvider, context: vscode.ExtensionContext) {
   const extensionFile = getExtensionFilePath(context)!;
@@ -31,7 +32,7 @@ export async function createAlert(cachedData: CachedDataProvider, context: vscod
   // Ask the user to select a metric
   let metricKeys = getAllMetricKeysFromDataSource(extension);
   if (metricKeys.length === 0 && extension.metrics) {
-    metricKeys = extension.metrics.map(metric => metric.key);
+    metricKeys = extension.metrics.map((metric: MetricMetadata) => metric.key);
   }
 
   if (metricKeys.length === 0) {

--- a/src/commandPalette/createDashboard.ts
+++ b/src/commandPalette/createDashboard.ts
@@ -21,6 +21,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { EnvironmentsTreeDataProvider } from "../treeViews/environmentsTreeView";
 import { getExtensionFilePath } from "../utils/fileSystem";
 import { CachedDataProvider } from "../utils/dataCaching";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 
 /**
  * Workflow for creating an overview dashboard based on the content of the extension.yaml.
@@ -62,7 +63,7 @@ export async function createOverviewDashboard(
   if (!extension.dashboards) {
     extension.dashboards = [{ path: DASHBOARD_PATH }];
     writeFileSync(extensionFile, cachedData.getStringifiedExtension(extension));
-  } else if (extension.dashboards.findIndex(d => d.path === DASHBOARD_PATH) === -1) {
+  } else if (extension.dashboards.findIndex( (d: { path: string }) => d.path === DASHBOARD_PATH) === -1) {
     extension.dashboards.push({ path: DASHBOARD_PATH });
     writeFileSync(extensionFile, cachedData.getStringifiedExtension(extension));
   }

--- a/src/commandPalette/createDocumentation.ts
+++ b/src/commandPalette/createDocumentation.ts
@@ -20,6 +20,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { getAllMetricsByFeatureSet } from "../utils/extensionParsing";
 import { getExtensionFilePath } from "../utils/fileSystem";
 import { CachedDataProvider } from "../utils/dataCaching";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 
 /**
  * Delivers the "Create documentation" command functionality.

--- a/src/diagnostics/diagnostics.ts
+++ b/src/diagnostics/diagnostics.ts
@@ -15,6 +15,7 @@
  */
 
 import * as vscode from "vscode";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 import { checkDtInternalProperties } from "../utils/conditionCheckers";
 import { CachedDataProvider } from "../utils/dataCaching";
 import {

--- a/src/dynatrace-api/configuration_v1/extensions.ts
+++ b/src/dynatrace-api/configuration_v1/extensions.ts
@@ -1,0 +1,55 @@
+/**
+  Copyright 2023 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+  import { HttpClient } from "../http_client";
+
+  /**
+   * Implementation of the Extensions V2 API
+   */
+  export class ExtensionsServiceV1 {
+    private readonly endpoint = "/api/config/v1/extensions";
+    private readonly httpClient: HttpClient;
+  
+    constructor(httpClient: HttpClient) {
+      this.httpClient = httpClient;
+    }
+  
+    /**
+     * Gets the list of uploaded v1 extensions.
+     * @returns list of extensions
+     */
+    async getExtensions(): Promise<ExtensionV1DTO[]> {
+      const extensions = [];
+      let nextPageKey = null;
+      do {
+        const res: ExtensionV1ListDto = await this.httpClient.makeRequest(this.endpoint, { nextPageKey });
+        extensions.push(...res.extensions);
+        nextPageKey = res.nextPageKey;
+      } while (nextPageKey);
+      return extensions;
+    }
+
+    /**
+     * Get the binary of a v1 extension
+     * @param extensionId the id of the extension
+     * @returns the binary of the extension
+     */
+    async getExtensionBinary(extensionId: string): Promise<Uint8Array> {
+      return this.httpClient.makeRequest(`${this.endpoint}/${extensionId}/binary`, null, "GET", {}, null, null, "arraybuffer");
+    }
+  
+  }
+  

--- a/src/dynatrace-api/dynatrace.ts
+++ b/src/dynatrace-api/dynatrace.ts
@@ -17,6 +17,7 @@
 import { CredentialVaultService } from "./configuration_v1/credentialVault";
 import { DashboardService } from "./configuration_v1/dashboards";
 import { ExtensionsServiceV2 } from "./environment_v2/extensions";
+import { ExtensionsServiceV1 } from "./configuration_v1/extensions";
 import { MetricService } from "./environment_v2/metrics";
 import { EntityServiceV2 } from "./environment_v2/monitoredEntities";
 import { SettingsService } from "./environment_v2/settings";
@@ -28,6 +29,7 @@ import { HttpClient } from "./http_client";
 export class Dynatrace {
   private readonly _httpClient: HttpClient;
   public readonly extensionsV2: ExtensionsServiceV2;
+  public readonly extensionsV1: ExtensionsServiceV1;
   public readonly credentialVault: CredentialVaultService;
   public readonly entitiesV2: EntityServiceV2;
   public readonly metrics: MetricService;
@@ -46,5 +48,6 @@ export class Dynatrace {
     this.metrics = new MetricService(this._httpClient);
     this.settings = new SettingsService(this._httpClient);
     this.dashboards = new DashboardService(this._httpClient);
+    this.extensionsV1 = new ExtensionsServiceV1(this._httpClient);
   }
 }

--- a/src/dynatrace-api/http_client.ts
+++ b/src/dynatrace-api/http_client.ts
@@ -46,7 +46,8 @@ export class HttpClient {
     method: string = "GET",
     headers: any = {},
     queryParams?: any,
-    files?: any
+    files?: any,
+    responseType?: any
   ): Promise<any> {
     let url = `${this.baseUrl}${path}`;
 
@@ -80,6 +81,7 @@ export class HttpClient {
         params: params,
         method: method,
         data: files ? form! : body,
+        responseType
       })
       .then((res) => {
         if (res.status >= 400) {

--- a/src/dynatrace-api/interfaces/extensions.ts
+++ b/src/dynatrace-api/interfaces/extensions.ts
@@ -27,6 +27,20 @@ interface MinimalExtension {
   version: string;
 }
 
+interface ExtensionV1ListDto {
+  extensions: ExtensionV1DTO[];
+  totalResults: number;
+  nextPageKey?: string;
+}
+
+interface ExtensionV1DTO {
+  id: string;
+  name: string;
+  type: "ACTIVEGATE" | "CODEMODULE" | "JMX" | "ONEAGENT" | "PMI" | "UNKNOWN";
+}
+
+
+
 interface ExtensionMonitoringConfiguration {
   objectId: string;
   scope: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ import { runWMIQuery, WmiQueryResult } from "./codeLens/utils/wmiUtils";
 import { WMIQueryResultsPanel } from "./webviews/wmiQueryResults";
 import { WmiCompletionProvider } from "./codeCompletions/wmi";
 import { createAlert } from "./commandPalette/createAlert";
+import { convertJMXExtension } from "./commandPalette/convertJMXExtension";
 import { SnmpActionProvider } from "./codeActions/snmp";
 
 /**
@@ -390,6 +391,11 @@ function registerCommandPaletteCommands(
         createAlert(cachedDataProvider, context);
       }
     }),
+    // Convert JMX Extension from 1.0 to 2.0
+    vscode.commands.registerCommand("dt-ext-copilot.convertJmxExtension", async () => {
+        convertJMXExtension(context, (await tenantsProvider.getDynatraceClient())!);
+    })
+
   ];
 }
 

--- a/src/interfaces/extensionDocs.ts
+++ b/src/interfaces/extensionDocs.ts
@@ -27,9 +27,9 @@ interface DashboardDoc {
 interface MetricDoc {
   key: string;
   name: string;
-  description: string;
-  unit: string;
-  tags: string[];
+  description?: string;
+  unit?: string;
+  tags?: string[];
   entities: string[];
 }
 

--- a/src/interfaces/extensionMeta.ts
+++ b/src/interfaces/extensionMeta.ts
@@ -106,9 +106,9 @@ interface MetricMetadata {
   key: string;
   metadata: {
     displayName: string;
-    description: string;
-    unit: string;
-    tags: string[];
+    description?: string;
+    unit?: string;
+    tags?: string[];
   };
 }
 
@@ -260,4 +260,72 @@ interface PythonDatasource {
       path: string;
     };
   };
+}
+
+export interface JMXExtensionV2 {
+  name: string;
+  version: string;
+  minDynatraceVersion: string;
+  author: {
+      name: string;
+  }
+  jmx?: {
+    groups: JMXGroup[];
+  }
+  metrics?: MetricMetadata[];
+}
+
+interface JMXGroup extends DatasourceGroup {
+  group: string;
+  subgroups: JMXSubGroup[];
+}
+
+export interface JMXSubGroup extends SubGroup {
+  subgroup: string;
+  query: string;
+  queryFilters?: JMXFilter[];
+}
+
+interface JMXFilter {
+  field: string;
+  filter: string;
+}
+
+export interface JMXExtensionV1 {
+  name: string;
+  metricGroup?: string;
+  version: string;
+  type: string;
+  metrics: MetricDto[];
+}
+
+export interface MetricDto {
+  timeseries: TimeseriesDto;
+  source: SourceDto;
+  entity: string;
+}
+
+export interface TimeseriesDto {
+  key: string;
+  unit: string;
+  displayname: string;
+  dimensions: string[];
+}
+
+export interface SourceDto {
+  domain: string;
+  keyProperties: {[key: string]: string};
+  allowAdditionalKeys: boolean;
+  attribute: string;
+  calculateRate: boolean;
+  calculateDelta: boolean;
+  splitting?: SplittingDto;
+  splittings?: SplittingDto[];
+  aggregation?: string;
+}
+
+export interface SplittingDto {
+  keyProperty: string;
+  name: string;
+  type: string;
 }

--- a/src/interfaces/extensionMeta.ts
+++ b/src/interfaces/extensionMeta.ts
@@ -19,7 +19,7 @@ interface TopologyStub {
   relationships: RelationshipStub[];
 }
 
-interface TopologyType {
+export interface TopologyType {
   displayName: string;
   name: string;
   rules: {
@@ -58,7 +58,7 @@ interface MetricStub {
   featureSet?: string;
 }
 
-interface DatasourceGroup {
+export interface DatasourceGroup {
   featureSet?: string;
   dimensions?: DimensionStub[];
   metrics?: MetricStub[];
@@ -102,7 +102,7 @@ interface WmiSubGroup extends SubGroup {
   type?: "logfileEvent" | "metric" | "notificationEvent";
 }
 
-interface MetricMetadata {
+export interface MetricMetadata {
   key: string;
   metadata: {
     displayName: string;
@@ -225,7 +225,7 @@ interface SingleMetricConfig {
   metric: { metricSelector: string };
 }
 
-interface ExtensionStub {
+export interface ExtensionStub {
   name: string;
   version: string;
   minDynatraceVersion: string;

--- a/src/utils/dataCaching.ts
+++ b/src/utils/dataCaching.ts
@@ -21,6 +21,7 @@ import { ValidationStatus } from "../codeLens/utils/selectorUtils";
 import { PromData } from "../codeLens/prometheusScraper";
 import { WmiQueryResult } from "../codeLens/utils/wmiUtils";
 import { fetchOID, OidInformation } from "./snmp";
+import { ExtensionStub } from "../interfaces/extensionMeta";
 
 /**
  * A utility class for caching reusable data that other components depend on.

--- a/src/utils/extensionParsing.ts
+++ b/src/utils/extensionParsing.ts
@@ -14,6 +14,8 @@
   limitations under the License.
  */
 
+import { DatasourceGroup, ExtensionStub } from "../interfaces/extensionMeta";
+
 /**
  * Normalize semi-invalid versions of extension because they get re-written cluster-side.
  * E.g. version can be 3 and cluster will re-write to 3.0.0


### PR DESCRIPTION
Adds a new command pallet: `Convert JMX Extension`

The user can select one of:

* `Local (filesystem)` -> The user selects a file using a file dialog, it can be a extension zip or a plugin.json file
* `Remote (dynatrace environment)` -> The Dynatrace API is used to list all JMX v1 extensions

The user is then prompted with another file dialog, of where to save the generated extension file to.

I had to add one extra dependency (jszip) to deal with zip files.