### PR TITLE
Support multiple extra platforms when building Python extensions

### DIFF
--- a/src/commandPalette/buildExtension.ts
+++ b/src/commandPalette/buildExtension.ts
@@ -330,9 +330,10 @@ async function assemblePython(
 
   // Build
   await runCommand(
-    `dt-sdk build -k "${certKeyPath}" "${extensionDir}" -t "${workspaceStorage}" -e "${
-      process.platform === "win32" ? "linux_x86_64" : "win_amd64"
-    }"`,
+    `dt-sdk build -k "${certKeyPath}" "${extensionDir}" -t "${workspaceStorage}" ${
+      process.platform === "win32" ? "-e linux_x86_64"
+      : (process.platform === "linux" ? "-e win_amd64" : "-e linux_x86_64 -e win_amd64")
+    }`,
     oc,
     cancelToken,
     envOptions


### PR DESCRIPTION
This will fix #94. 

Also it works even while the underlying change in `dt-sdk` is not implemented yet.