### PR TITLE
correct 'alerts' to 'dashboards'

### DIFF
--- a/src/commandPalette/createDashboard.ts
+++ b/src/commandPalette/createDashboard.ts
@@ -74,7 +74,7 @@ export async function createOverviewDashboard(
       updatedExtensionText = extensionText;
     }
   } else {
-    updatedExtensionText = `${extensionText}\nalerts:\n  - path: ${DASHBOARD_PATH}\n`;
+    updatedExtensionText = `${extensionText}\ndashboards:\n  - path: ${DASHBOARD_PATH}\n`;
   }
 
   writeFileSync(extensionFile, updatedExtensionText);


### PR DESCRIPTION
The create overview dashboard command created the dash json and added to the extension.yaml but was using 'alerts' for this section instead of yaml.