### PR TITLE
ISSUE-274: generate valid YAML when using action on higher level

### DIFF
--- a/src/codeActions/prometheus.ts
+++ b/src/codeActions/prometheus.ts
@@ -26,7 +26,6 @@ import {
 import { createSingletonProvider } from "../utils/singleton";
 import { getBlockItemIndexAtLine, getParentBlocks } from "../utils/yamlParsing";
 import { buildMetricMetadataSnippet, indentSnippet } from "./utils/snippetBuildingUtils";
-import logging from "../utils/logging";
 
 /**
  * Provider for Code Actions that work with scraped Prometheus data to automatically


### PR DESCRIPTION
As per [issue 274](https://github.com/dynatrace-extensions/dynatrace-extensions-vscode/issues/274), when generating all scraped metrics from a group that only has the `metrics` section and no group name, the generated YAML code is invalid.

The solution is to provide a group name just before the generated piece of yaml code, as the metrics will already be divided into subgroups of maximum 100 elements.