### PR TITLE
Fix smartscape idComponent, `-` in names and node_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Version 2.10.1 (24.02.2026)
+
+### 🪲 Fixed in this version:
+
+- Fix duplicate entries in idComponents during topology conversion
+- Do not allow `-` in the entity type during topology conversion
+- Fix node_id to be unique per entity during topology conversion
+
+---
+
 ## Version 2.10.0 (27.01.2026)
 
 ### ✨ New in this version:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "extensions@dynatrace.com",
     "url": "https://info.dynatrace.com/global_all_wp_dynatrace_services_platform_extensions_fact_sheet_13656_fulfillment.html"
   },
-  "version": "2.10.0",
+  "version": "2.10.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/dynatrace-extensions/dynatrace-extensions-vscode.git"

--- a/src/commandPalette/convertTopology.ts
+++ b/src/commandPalette/convertTopology.ts
@@ -493,10 +493,10 @@ const createSmartscapeEdgeProcessor = (
     description,
     smartscapeEdge: {
       sourceType,
-      sourceIdFieldName: "node_id",
+      sourceIdFieldName: `dt.smartscape.${sourceType.toLowerCase()}`,
       edgeType,
       targetType,
-      targetIdFieldName: "node_id",
+      targetIdFieldName: `dt.smartscape.${targetType.toLowerCase()}`,
     },
   };
 };
@@ -1004,7 +1004,7 @@ const createSmartscapeNodeProcessor = (
     description,
     smartscapeNode: {
       nodeType: newName,
-      nodeIdFieldName: "node_id",
+      nodeIdFieldName: `dt.smartscape.${newName.toLowerCase()}`,
       idComponents,
       extractNode,
       nodeName,

--- a/src/commandPalette/convertTopology.ts
+++ b/src/commandPalette/convertTopology.ts
@@ -970,6 +970,16 @@ const createSmartscapeNodeProcessor = (
     ];
   }
 
+  // Remove duplicate idComponents (by idComponent string), keeping the first occurrence
+  const seenIdComponents = new Set<string>();
+  idComponents = idComponents.filter(component => {
+    if (seenIdComponents.has(component.idComponent)) {
+      return false;
+    }
+    seenIdComponents.add(component.idComponent);
+    return true;
+  });
+
   // Build fields to extract from attributes, filtering out blocked fields
   const fieldsToExtract = (rule.attributes ?? [])
     .filter(attr => !BLOCKED_FIELDS.includes(attr.key))

--- a/src/commandPalette/convertTopology.ts
+++ b/src/commandPalette/convertTopology.ts
@@ -725,8 +725,8 @@ const processLogsSource = async (
 
 const suggestNewTypeName = (currentName: string): string => {
   // Entities names should be uppercase and separated by '_'
-  // Example: cloudhub:org becomes CLOUDHUB_ORG
-  return currentName.toUpperCase().replace(/:/g, "_");
+  // Example: cloudhub:org becomes CLOUDHUB_ORG, cloud-application becomes CLOUD_APPLICATION
+  return currentName.toUpperCase().replace(/[:-]/g, "_");
 };
 
 /**

--- a/test/unit/__tests__/commandPalette/convertTopology.test.ts
+++ b/test/unit/__tests__/commandPalette/convertTopology.test.ts
@@ -139,6 +139,30 @@ describe("convertTopology", () => {
       });
     });
 
+    it("should use dt.smartscape.<type> format for nodeIdFieldName", async () => {
+      const { pipelineDocs } = await convertTopologyToOpenPipeline(extension, autoInputCallback);
+      const processors = pipelineDocs.metricPipeline?.smartscapeNodeExtraction?.processors || [];
+
+      processors.forEach((processor: OpenPipelineProcessor) => {
+        const nodeType = processor.smartscapeNode?.nodeType;
+        const nodeIdFieldName = processor.smartscapeNode?.nodeIdFieldName;
+        expect(nodeIdFieldName).toBe(`dt.smartscape.${nodeType?.toLowerCase()}`);
+      });
+    });
+
+    it("should use dt.smartscape.<type> format for edge sourceIdFieldName and targetIdFieldName", async () => {
+      const { pipelineDocs } = await convertTopologyToOpenPipeline(extension, autoInputCallback);
+      const edgeProcessors = pipelineDocs.metricPipeline?.smartscapeEdgeExtraction?.processors || [];
+
+      expect(edgeProcessors.length).toBeGreaterThan(0);
+
+      edgeProcessors.forEach((processor: OpenPipelineProcessor) => {
+        const edge = processor.smartscapeEdge;
+        expect(edge?.sourceIdFieldName).toBe(`dt.smartscape.${edge?.sourceType?.toLowerCase()}`);
+        expect(edge?.targetIdFieldName).toBe(`dt.smartscape.${edge?.targetType?.toLowerCase()}`);
+      });
+    });
+
     it("should handle custom input callback", async () => {
       const mockCallback: InputCallback = jest.fn(async (_prompt, suggestedValue) => {
         // Return custom value instead of suggested
@@ -213,7 +237,9 @@ describe("convertTopology", () => {
 
         const smartscapeNode = processor.smartscapeNode;
         expect(smartscapeNode).toHaveProperty("nodeType");
-        expect(smartscapeNode).toHaveProperty("nodeIdFieldName", "node_id");
+        expect(smartscapeNode).toHaveProperty("nodeIdFieldName");
+        // nodeIdFieldName should follow dt.smartscape.<type> format
+        expect(smartscapeNode?.nodeIdFieldName).toMatch(/^dt\.smartscape\..+/);
         expect(smartscapeNode).toHaveProperty("idComponents");
         expect(smartscapeNode).toHaveProperty("extractNode");
         expect(smartscapeNode).toHaveProperty("nodeName");

--- a/test/unit/__tests__/commandPalette/convertTopology.test.ts
+++ b/test/unit/__tests__/commandPalette/convertTopology.test.ts
@@ -28,7 +28,7 @@ import {
   OpenPipelineIdComponent,
   OpenPipelineProcessor,
 } from "../../../../src/interfaces/extensionDocs";
-import { ExtensionStub } from "../../../../src/interfaces/extensionMeta";
+import { ExtensionStub, TopologyType } from "../../../../src/interfaces/extensionMeta";
 
 jest.mock("../../../../src/utils/logging");
 
@@ -271,6 +271,39 @@ describe("convertTopology", () => {
             processor.matcher.includes("==") ||
             processor.matcher.includes("isNotNull"),
         ).toBe(true);
+      });
+    });
+
+    it("should not have duplicate idComponents", async () => {
+      // Craft a topology type with an idPattern that has duplicate field references
+      const typesWithDuplicateIdPattern: TopologyType[] = [
+        {
+          name: "custom:test_entity",
+          displayName: "Test Entity",
+          rules: [
+            {
+              idPattern: "test_{field1}_{field1}_{field2}_{field2}",
+              instanceNamePattern: "{field1}",
+              sources: [{ sourceType: "Metrics", condition: "$prefix(test.metric)" }],
+              attributes: [],
+            },
+          ],
+        },
+      ];
+
+      const { metricsProcessors } = await createProcessorsFromTopology(
+        typesWithDuplicateIdPattern,
+        [{ key: "test.metric.value", metadata: { displayName: "Test Metric" } }],
+        autoInputCallback,
+      );
+
+      expect(metricsProcessors.length).toBeGreaterThan(0);
+
+      metricsProcessors.forEach(processor => {
+        const idComponents = processor.smartscapeNode?.idComponents ?? [];
+        const idComponentNames = idComponents.map((c: OpenPipelineIdComponent) => c.idComponent);
+        const uniqueNames = [...new Set(idComponentNames)];
+        expect(idComponentNames).toEqual(uniqueNames);
       });
     });
 

--- a/test/unit/__tests__/commandPalette/convertTopology.test.ts
+++ b/test/unit/__tests__/commandPalette/convertTopology.test.ts
@@ -108,6 +108,37 @@ describe("convertTopology", () => {
       expect(uniqueNodeTypes).toContain("CLOUDHUB_APP");
     });
 
+    it("should replace hyphens with underscores in suggested type names", async () => {
+      const typesWithHyphens: TopologyType[] = [
+        {
+          name: "dt.entity.cloud-application",
+          displayName: "Cloud Application",
+          rules: [
+            {
+              idPattern: "app_{app.id}",
+              instanceNamePattern: "{app.name}",
+              sources: [{ sourceType: "Metrics", condition: "$prefix(cloud.app)" }],
+              attributes: [],
+            },
+          ],
+        },
+      ];
+
+      const { metricsProcessors } = await createProcessorsFromTopology(
+        typesWithHyphens,
+        [{ key: "cloud.app.cpu", metadata: { displayName: "CPU" } }],
+        autoInputCallback,
+      );
+
+      expect(metricsProcessors.length).toBeGreaterThan(0);
+
+      metricsProcessors.forEach(processor => {
+        const nodeType = processor.smartscapeNode?.nodeType;
+        expect(nodeType).not.toContain("-");
+        expect(nodeType).toBe("DT.ENTITY.CLOUD_APPLICATION");
+      });
+    });
+
     it("should handle custom input callback", async () => {
       const mockCallback: InputCallback = jest.fn(async (_prompt, suggestedValue) => {
         // Return custom value instead of suggested


### PR DESCRIPTION
* Prevent duplicate entries in `idComponents` during topology conversion by filtering out repeated components in `createSmartscapeNodeProcessor`.
* Enforce the `dt.smartscape.<type>` format for `nodeIdFieldName`, `sourceIdFieldName`, and `targetIdFieldName` in node and edge processors
* Disallow hyphens (`-`) in suggested entity type names by replacing them with underscores

