### PR TITLE
Add setting parameter to choose what Python version to build against with build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Version 2.10.2 (05.03.2026)
 
-⚠️ The `Dynatrace Extensions: Build` command for Python extensions now requires `dt-extensions-sdk` version `1.8.0+`.
-
 ### ✨ New in this version:
 
 - Support for building extensions with Python 3.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Version 2.10.2 (05.03.2026)
 
+⚠️ The `Dynatrace Extensions: Build` command for Python extensions now requires `dt-extensions-sdk` version `1.8.0+`.
+
 ### ✨ New in this version:
 
-⚠️ The `Dynatrace Extensions: Build` command for Python extensions now requires `dt-extensions-sdk` version `1.8.0+`.
 - Support for building extensions with Python 3.14
   - A new configuration parameter has been added to the settings, which allows you to choose from building extensions with Python support for 3.10, 3.14, or both.
   - This parameter will be removed by October 2026 and only 3.14 will be available afterwards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## Version 2.10.2 (05.03.2026)
+
+### ✨ New in this version:
+
+⚠️ The `Dynatrace Extensions: Build` command for Python extensions now requires `dt-extensions-sdk` version `1.8.0+`.
+- Support for building extensions with Python 3.14
+  - A new configuration parameter has been added to the settings, which allows you to choose from building extensions with Python support for 3.10, 3.14, or both.
+  - This parameter will be removed by October 2026 and only 3.14 will be available afterwards.
+
+---
+
 ## Version 2.10.1 (24.02.2026)
 
 ### 🪲 Fixed in this version:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "extensions@dynatrace.com",
     "url": "https://info.dynatrace.com/global_all_wp_dynatrace_services_platform_extensions_fact_sheet_13656_fulfillment.html"
   },
-  "version": "2.10.1",
+  "version": "2.10.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/dynatrace-extensions/dynatrace-extensions-vscode.git"

--- a/package.json
+++ b/package.json
@@ -552,8 +552,21 @@
             "items": {
               "type": "string"
             },
+            "order": 1,
             "description": "A list of extra platforms to build Python wheels for. This setting overwrites the default list of linux_x86_64 and win_amd_64",
             "scope": "resource"
+          },
+          "dynatraceExtensions.pythonBuildVersions": {
+            "type": "string",
+            "description": "The Python versions that will be used when running the 'Dynatrace extensions: Build' command.",
+            "enum": [
+              "3.10 + 3.14",
+              "3.10",
+              "3.14"
+            ],
+            "order": 2,
+            "scope": "resource",
+            "default": "3.10 + 3.14"
           }
         }
       }

--- a/src/commandPalette/buildExtension.ts
+++ b/src/commandPalette/buildExtension.ts
@@ -307,9 +307,10 @@ async function assemblePython(oc: vscode.OutputChannel, cancelToken: vscode.Canc
     const workspaceStorage = getWorkspaceStorage();
     const certKeyPath = getDevCertKey();
     const setupPyDir = path.resolve(await getManifestDirPath(), "..");
+    const pythonVersionsParam = getPythonVersionsParameter();
 
     await runCommand(
-      `dt-sdk build -k "${certKeyPath}" -t "${workspaceStorage}" ${platformsParam} "${setupPyDir}"`,
+      `dt-sdk build -k "${certKeyPath}" -t "${workspaceStorage}" ${platformsParam} ${pythonVersionsParam} "${setupPyDir}"`,
       oc,
       cancelToken,
       envOptions,
@@ -368,6 +369,21 @@ const getExtraPlatformsParameter = () => {
   }
 
   return platformString;
+};
+
+const getPythonVersionsParameter = () => {
+  const pythonBuildVersions = vscode.workspace
+    .getConfiguration("dynatraceExtensions", null)
+    .get<string>("pythonBuildVersions");
+  switch (pythonBuildVersions) {
+    case "3.10":
+      return "-p 3.10";
+    case "3.14":
+      return "-p 3.14";
+    case "3.10 + 3.14":
+    default:
+      return "-p 3.10 -p 3.14";
+  }
 };
 
 /**

--- a/src/commandPalette/buildExtension.ts
+++ b/src/commandPalette/buildExtension.ts
@@ -313,7 +313,7 @@ async function assemblePython(oc: vscode.OutputChannel, cancelToken: vscode.Canc
       cancelToken,
       envOptions,
     );
-    const supportsBuildVersions = parsePythonSDKVersion(sdkVersionOutput ?? "");
+    const supportsBuildVersions = doesSDKSupportVersioning(sdkVersionOutput ?? "");
     let pythonVersionsParam = "";
     if (!supportsBuildVersions) {
       void vscode.window.showWarningMessage(
@@ -385,7 +385,7 @@ const getExtraPlatformsParameter = () => {
   return platformString;
 };
 
-const parsePythonSDKVersion = (sdkVersionOutput: string): boolean => {
+const doesSDKSupportVersioning = (sdkVersionOutput: string): boolean => {
   let response = false;
   const versionSplit = sdkVersionOutput.split(" ");
   const version = versionSplit[versionSplit.length - 1].trim();

--- a/src/commandPalette/buildExtension.ts
+++ b/src/commandPalette/buildExtension.ts
@@ -53,7 +53,7 @@ import {
 import { loopSafeWait } from "../utils/general";
 import logger from "../utils/logging";
 import { getPythonVenvOpts } from "../utils/otherExtensions";
-import { runCommand } from "../utils/subprocesses";
+import { runCommand, runCommandWithOutput } from "../utils/subprocesses";
 import { ConfirmOption, showConfirmationInformationMessage } from "../utils/vscode";
 
 const logTrace = ["commandPalette", "buildExtension"];
@@ -307,7 +307,21 @@ async function assemblePython(oc: vscode.OutputChannel, cancelToken: vscode.Canc
     const workspaceStorage = getWorkspaceStorage();
     const certKeyPath = getDevCertKey();
     const setupPyDir = path.resolve(await getManifestDirPath(), "..");
-    const pythonVersionsParam = getPythonVersionsParameter();
+    const sdkVersionOutput = await runCommandWithOutput(
+      "dt-sdk version",
+      oc,
+      cancelToken,
+      envOptions,
+    );
+    const supportsBuildVersions = parsePythonSDKVersion(sdkVersionOutput ?? "");
+    let pythonVersionsParam = "";
+    if (!supportsBuildVersions) {
+      void vscode.window.showWarningMessage(
+        `Your version of dt-sdk ${sdkVersionOutput} is below 1.8.0 and does not support specifying Python build versions. Building only for Python 3.10.`,
+      );
+    } else {
+      pythonVersionsParam = getPythonVersionsParameter();
+    }
 
     await runCommand(
       `dt-sdk build -k "${certKeyPath}" -t "${workspaceStorage}" ${platformsParam} ${pythonVersionsParam} "${setupPyDir}"`,
@@ -369,6 +383,21 @@ const getExtraPlatformsParameter = () => {
   }
 
   return platformString;
+};
+
+const parsePythonSDKVersion = (sdkVersionOutput: string): boolean => {
+  let response = false;
+  const versionSplit = sdkVersionOutput.split(" ");
+  const version = versionSplit[versionSplit.length - 1].trim();
+  version.split(".").forEach((num, index) => {
+    if (index === 0 && parseInt(num) > 1) {
+      response = true;
+    }
+    if (index === 1 && parseInt(num) > 7) {
+      response = true;
+    }
+  });
+  return response;
 };
 
 const getPythonVersionsParameter = () => {

--- a/src/commandPalette/initWorkspace.ts
+++ b/src/commandPalette/initWorkspace.ts
@@ -66,7 +66,7 @@ const PROJECT_TYPE: Record<string, vscode.QuickPickItem> = {
   pythonExtension: {
     label: "Python Extension",
     iconPath: new vscode.ThemeIcon("terminal"),
-    detail: "Develop an Extension based on the Python datasource. Requires python 3.10",
+    detail: "Develop an Extension based on the Python datasource. Requires python 3.10 or 3.14",
   },
   jmxConversion: {
     label: "JMX 1.0 Conversion",

--- a/src/utils/subprocesses.ts
+++ b/src/utils/subprocesses.ts
@@ -24,23 +24,20 @@ import logger from "./logging";
 
 const logTrace = ["utils", "subprocesses"];
 
-/**
- * Executes the given command in a child process and wraps the whole thing in a Promise.
- * This way the execution is async but other code can await it.
- * On success, returns the exit code (if any). Will throw any error with the message
- * part of the stderr (the rest is included via output channel)
- * @param command the command to execute
- * @param oc JSON output channel to communicate error details
- * @param cancelToken cancellation token to cancel the process
- * @param envOptions options to pass to the child process
- * @returns exit code or `null`
- */
-export function runCommand(
+type CommandResultType = number | string | null;
+
+function runSubprocess<T extends CommandResultType>(
   command: string,
-  oc?: vscode.OutputChannel,
-  cancelToken?: vscode.CancellationToken,
-  envOptions?: ExecOptions,
-): Promise<number | null> {
+  oc: vscode.OutputChannel | undefined,
+  cancelToken: vscode.CancellationToken | undefined,
+  envOptions: ExecOptions | undefined,
+  resultSelector: (
+    code: number | null,
+    stdout: string,
+    stderr: string,
+    cancelToken?: vscode.CancellationToken,
+  ) => T,
+): Promise<T> {
   const fnLogTrace = [...logTrace, "runCommand"];
   logger.debug(`Running command "${command}"`, ...fnLogTrace);
 
@@ -59,7 +56,8 @@ export function runCommand(
     p.stderr?.on("data", (data: Buffer) => (stderr += data.toString()));
     p.on("exit", code => {
       if (cancelToken?.isCancellationRequested) {
-        return resolve(1);
+        resolve(resultSelector(code, stdout, stderr, cancelToken));
+        return;
       }
       if (code !== 0) {
         let [shortMessage, details] = [stderr, [""]];
@@ -80,9 +78,62 @@ export function runCommand(
           oc.show();
         }
         reject(Error(shortMessage));
+        return;
       }
       logger.debug(stdout, ...fnLogTrace);
-      return resolve(code);
+      resolve(resultSelector(code, stdout, stderr, cancelToken));
     });
   });
+}
+
+/**
+ * Executes the given command in a child process and wraps the whole thing in a Promise.
+ * This way the execution is async but other code can await it.
+ * On success, returns the exit code (if any). Will throw any error with the message
+ * part of the stderr (the rest is included via output channel)
+ * @param command the command to execute
+ * @param oc JSON output channel to communicate error details
+ * @param cancelToken cancellation token to cancel the process
+ * @param envOptions options to pass to the child process
+ * @returns exit code or `null`
+ */
+export function runCommand(
+  command: string,
+  oc?: vscode.OutputChannel,
+  cancelToken?: vscode.CancellationToken,
+  envOptions?: ExecOptions,
+): Promise<number | null> {
+  return runSubprocess<number | null>(
+    command,
+    oc,
+    cancelToken,
+    envOptions,
+    (code, _stdout, _stderr, token) => (token?.isCancellationRequested ? 1 : code),
+  );
+}
+
+/**
+ * Executes the given command in a child process and wraps the whole thing in a Promise.
+ * This way the execution is async but other code can await it.
+ * On success, returns the output (if any). Will throw any error with the message
+ * part of the stderr (the rest is included via output channel)
+ * @param command the command to execute
+ * @param oc JSON output channel to communicate error details
+ * @param cancelToken cancellation token to cancel the process
+ * @param envOptions options to pass to the child process
+ * @returns command output or `null`
+ */
+export function runCommandWithOutput(
+  command: string,
+  oc?: vscode.OutputChannel,
+  cancelToken?: vscode.CancellationToken,
+  envOptions?: ExecOptions,
+): Promise<string | null> {
+  return runSubprocess<string | null>(
+    command,
+    oc,
+    cancelToken,
+    envOptions,
+    (_code, stdout, _stderr, token) => (token?.isCancellationRequested ? "-" : stdout),
+  );
 }


### PR DESCRIPTION
Added a configuration parameter under settings to allow customers to define if they want to build Python extensions with Python 3.10, 3.14 or both.

If the `dt-extension-sdk` version is too low, it does not include the parameters and just builds for 3.10.