### PR TITLE
OpenPipeline schema validation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ const config = {
     "src/utils/cryptography.ts",
     "src/utils/general.ts",
     "src/utils/extensionParsing.ts",
+    "src/utils/openPipelineSchemaTranslation.ts",
   ],
   moduleNameMapper: {
     "@common": "<rootDir>/common",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynatrace-extensions",
-  "version": "2.10.0",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dynatrace-extensions",
-      "version": "2.10.0",
+      "version": "2.10.2",
       "dependencies": {
         "axios": "^1.7.2",
         "chalk": "^4.1.2",
@@ -1421,10 +1421,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1468,10 +1469,11 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1498,27 +1500,6 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1841,10 +1822,11 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2796,10 +2778,11 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2853,10 +2836,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3129,13 +3113,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
-      "integrity": "sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -4748,10 +4732,11 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4876,10 +4861,11 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4953,10 +4939,11 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5246,21 +5233,23 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -5280,9 +5269,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -5499,16 +5488,37 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-      "license": "BlueOak-1.0.0",
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "license": "MIT",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6612,10 +6622,11 @@
       }
     },
     "node_modules/jest-config/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6974,10 +6985,11 @@
       }
     },
     "node_modules/jest-runtime/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7621,12 +7633,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8476,9 +8489,9 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8753,10 +8766,11 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9525,10 +9539,11 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9854,10 +9869,11 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
-      "dev": true
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/src/commandPalette/loadSchemas.ts
+++ b/src/commandPalette/loadSchemas.ts
@@ -20,53 +20,54 @@ import axios from "axios";
 import vscode from "vscode";
 import { Dynatrace } from "../dynatrace-api/dynatrace";
 import { getActivationContext } from "../extension";
+import { OPENPIPELINE_SCHEMA_CONFIGS } from "../interfaces/openPipelineSchemas";
 import { getDynatraceClient } from "../treeViews/tenantsTreeView";
 import { checkTenantConnected } from "../utils/conditionCheckers";
 import { getExtensionFilePath } from "../utils/fileSystem";
 import logger from "../utils/logging";
+import { translateSchema } from "../utils/openPipelineSchemaTranslation";
 import { ConfirmOption, showQuickPick, showQuickPickConfirm } from "../utils/vscode";
 
 const logTrace = ["commandPalette", "loadSchemas"];
 
 /**
- * Configures JSON schemas for OpenPipeline files (*.pipeline.json and *.source.json)
- * These schemas are downloaded alongside the extension schema in the global storage
- * @param schemaLocation - The path to the schema version folder (e.g., globalStorage/1.900.0/)
+ * Compares two dot-separated version strings numerically.
+ * Returns a negative number if a < b, 0 if equal, positive if a > b.
+ */
+function compareVersions(a: string, b: string): number {
+  const partsA = a.split(".").map(Number);
+  const partsB = b.split(".").map(Number);
+  const length = Math.max(partsA.length, partsB.length);
+  for (let i = 0; i < length; i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Configures JSON schemas for OpenPipeline files by updating VSCode workspace settings.
+ * Maps each schema config's file pattern to its converted schema file on disk.
+ * @param schemaLocation - The path to the openpipeline schema folder in global storage
  */
 export const configureOpenPipelineJSONSchemas = (schemaLocation: string): void => {
   const fnLogTrace = [...logTrace, "configureOpenPipelineJSONSchemas"];
 
-  const pipelineSchemaPath = vscode.Uri.file(
-    path.join(schemaLocation, "openpipeline.pipeline.schema.json"),
-  ).toString();
-  const sourceSchemaPath = vscode.Uri.file(
-    path.join(schemaLocation, "openpipeline.source.schema.json"),
-  ).toString();
-
-  // Get existing json.schemas configuration
   const config = vscode.workspace.getConfiguration();
   const existingSchemas =
     config.get<Array<{ fileMatch: string[]; url: string }>>("json.schemas") || [];
 
-  // Remove any existing openpipeline schemas to avoid duplicates
+  // Remove any existing openpipeline schema entries to avoid duplicates
   const filteredSchemas = existingSchemas.filter(
-    schema =>
-      !schema.fileMatch.some(
-        match => match.endsWith(".pipeline.json") || match.endsWith(".source.json"),
-      ),
+    schema => !schema.fileMatch.some(match => match.includes("openpipeline")),
   );
 
-  // Add our openpipeline schemas
   const newSchemas = [
     ...filteredSchemas,
-    {
-      fileMatch: ["*.pipeline.json"],
-      url: pipelineSchemaPath,
-    },
-    {
-      fileMatch: ["*.source.json"],
-      url: sourceSchemaPath,
-    },
+    ...OPENPIPELINE_SCHEMA_CONFIGS.map(({ filePattern, outputFilename }) => ({
+      fileMatch: [filePattern],
+      url: vscode.Uri.file(path.join(schemaLocation, outputFilename)).toString(),
+    })),
   ];
 
   config
@@ -77,6 +78,38 @@ export const configureOpenPipelineJSONSchemas = (schemaLocation: string): void =
 
   logger.debug("OpenPipeline JSON schemas configured", ...fnLogTrace);
 };
+
+/**
+ * Downloads OpenPipeline schemas from Dynatrace, converts them to JSON Schema,
+ * and writes the converted files to the openpipeline folder in global storage.
+ * Individual download failures are logged as warnings but do not affect overall success.
+ */
+async function downloadAndConvertOpenPipelineSchemas(
+  dt: Dynatrace,
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const fnLogTrace = [...logTrace, "downloadAndConvertOpenPipelineSchemas"];
+  const openpipelineDir = path.join(context.globalStorageUri.fsPath, "openpipeline");
+  mkdirSync(openpipelineDir, { recursive: true });
+
+  for (const schemaConfig of OPENPIPELINE_SCHEMA_CONFIGS) {
+    try {
+      const rawSchema = await dt.settings.getSchema(schemaConfig.schemaId);
+      const converted = translateSchema(rawSchema);
+      const outputPath = path.join(openpipelineDir, schemaConfig.outputFilename);
+      writeFileSync(outputPath, JSON.stringify(converted, null, 2));
+      logger.debug(`Converted OpenPipeline schema: ${schemaConfig.schemaId}`, ...fnLogTrace);
+    } catch (err) {
+      logger.notify(
+        "WARN",
+        `Failed to download OpenPipeline schema ${schemaConfig.schemaId}: ${(err as Error).message}`,
+        ...fnLogTrace,
+      );
+    }
+  }
+
+  configureOpenPipelineJSONSchemas(openpipelineDir);
+}
 
 export const loadSchemasWorkflow = async () => {
   if (await checkTenantConnected()) {
@@ -153,7 +186,8 @@ export async function loadSchemas(dt: Dynatrace): Promise<boolean> {
   });
 
   // Configure JSON schemas for OpenPipeline files
-  configureOpenPipelineJSONSchemas(location);
+  const openpipelineDir = path.join(context.globalStorageUri.fsPath, "openpipeline");
+  configureOpenPipelineJSONSchemas(openpipelineDir);
 
   try {
     // If extension.yaml already exists, update the version there too
@@ -244,6 +278,13 @@ function downloadSchemaFiles(location: string, version: string, dt: Dynatrace) {
         .catch(async err => {
           logger.notify("ERROR", (err as Error).message, ...fnLogTrace);
         });
+
+      // Download and convert OpenPipeline schemas for versions >= 1.330.0
+      if (compareVersions(version, "1.330.0") >= 0) {
+        progress.report({ message: "Downloading OpenPipeline schemas" });
+        const context = getActivationContext();
+        await downloadAndConvertOpenPipelineSchemas(dt, context);
+      }
     },
   );
 }

--- a/src/dynatrace-api/environment_v2/settings.ts
+++ b/src/dynatrace-api/environment_v2/settings.ts
@@ -86,6 +86,19 @@ export class SettingsService {
   }
 
   /**
+   * Fetches a single settings schema by its ID.
+   * @param schemaId The full schema ID (e.g., "builtin:openpipeline.metrics.pipelines")
+   * @param signal cancellation signal
+   * @returns the raw schema definition
+   */
+  async getSchema(schemaId: string, signal?: AbortSignal): Promise<unknown> {
+    return this.httpClient.makeRequest({
+      path: `${this.schemasEndpoint}/${schemaId}`,
+      signal,
+    });
+  }
+
+  /**
    * Creates a new settings object.
    * You can upload several objects at once. In that case each object returns its own response code.
    * @param payload Contains the settings objects to be created.

--- a/src/interfaces/openPipelineSchemas.ts
+++ b/src/interfaces/openPipelineSchemas.ts
@@ -1,0 +1,157 @@
+/**
+  Copyright 2022 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+// ---------------------------------------------------------------------------
+// Configuration for OpenPipeline schema download and conversion
+// ---------------------------------------------------------------------------
+
+export interface OpenPipelineSchemaConfig {
+  schemaId: string;
+  filePattern: string;
+  outputFilename: string;
+}
+
+export const OPENPIPELINE_SCHEMA_CONFIGS: OpenPipelineSchemaConfig[] = [
+  {
+    schemaId: "builtin:openpipeline.metrics.pipelines",
+    filePattern: "**/openpipeline/*metrics.pipeline.json",
+    outputFilename: "metrics.pipeline.schema.json",
+  },
+  {
+    schemaId: "builtin:openpipeline.metrics.ingest-sources",
+    filePattern: "**/openpipeline/*metrics.source.json",
+    outputFilename: "metrics.source.schema.json",
+  },
+  {
+    schemaId: "builtin:openpipeline.logs.pipelines",
+    filePattern: "**/openpipeline/*logs.pipeline.json",
+    outputFilename: "logs.pipeline.schema.json",
+  },
+  {
+    schemaId: "builtin:openpipeline.logs.ingest-sources",
+    filePattern: "**/openpipeline/*logs.source.json",
+    outputFilename: "logs.source.schema.json",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Dynatrace schema types (input format)
+// ---------------------------------------------------------------------------
+
+export type DtTypeRef = { $ref: string };
+export type DtPropertyType = string | DtTypeRef;
+
+export interface DtConstraint {
+  type: string;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+}
+
+export interface DtItemDef {
+  type: DtPropertyType;
+  constraints?: DtConstraint[];
+}
+
+export interface DtPreconditionEquals {
+  type: "EQUALS";
+  property: string;
+  expectedValue: unknown;
+}
+
+export interface DtPreconditionNot {
+  type: "NOT";
+  precondition: DtPrecondition;
+}
+
+export interface DtPreconditionIn {
+  type: "IN";
+  property: string;
+  expectedValues: unknown[];
+}
+
+export type DtPrecondition = DtPreconditionEquals | DtPreconditionNot | DtPreconditionIn;
+
+export interface DtPropertyDef {
+  displayName?: string;
+  description?: string;
+  type: DtPropertyType;
+  nullable?: boolean;
+  constraints?: DtConstraint[];
+  items?: DtItemDef;
+  minObjects?: number;
+  maxObjects?: number;
+  precondition?: DtPrecondition;
+  default?: unknown;
+}
+
+export interface DtTypeDef {
+  type: "object";
+  displayName?: string;
+  description?: string;
+  properties: Record<string, DtPropertyDef>;
+}
+
+export interface DtEnumItem {
+  value: string;
+}
+
+export interface DtEnumDef {
+  type: "enum";
+  displayName?: string;
+  description?: string;
+  items: DtEnumItem[];
+}
+
+export interface DtSchema {
+  schemaId: string;
+  displayName?: string;
+  description?: string;
+  enums?: Record<string, DtEnumDef>;
+  types?: Record<string, DtTypeDef>;
+  properties: Record<string, DtPropertyDef>;
+}
+
+// ---------------------------------------------------------------------------
+// JSON Schema types (output format — draft-07)
+// ---------------------------------------------------------------------------
+
+export interface JsonSchema {
+  $schema?: string;
+  $ref?: string;
+  $defs?: Record<string, JsonSchema>;
+  title?: string;
+  description?: string;
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+  items?: JsonSchema;
+  anyOf?: JsonSchema[];
+  allOf?: JsonSchema[];
+  enum?: unknown[];
+  const?: unknown;
+  not?: JsonSchema;
+  if?: JsonSchema;
+  then?: JsonSchema;
+  else?: JsonSchema;
+  minLength?: number;
+  maxLength?: number;
+  minItems?: number;
+  maxItems?: number;
+  uniqueItems?: boolean;
+  pattern?: string;
+}

--- a/src/utils/openPipelineSchemaTranslation.ts
+++ b/src/utils/openPipelineSchemaTranslation.ts
@@ -1,0 +1,261 @@
+/**
+  Copyright 2022 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import {
+  DtConstraint,
+  DtEnumDef,
+  DtItemDef,
+  DtPrecondition,
+  DtPropertyDef,
+  DtPropertyType,
+  DtSchema,
+  DtTypeDef,
+  DtTypeRef,
+  JsonSchema,
+} from "../interfaces/openPipelineSchemas";
+
+// ---------------------------------------------------------------------------
+// Translation helpers
+// ---------------------------------------------------------------------------
+
+function isTypeRef(type: DtPropertyType): type is DtTypeRef {
+  return typeof type === "object" && "$ref" in type;
+}
+
+/** Dynatrace $ref paths use "#/types/" or "#/enums/" — map both to "#/$defs/" */
+export function translateRef(ref: string): string {
+  return ref.replace(/^#\/(types|enums)\//, "#/$defs/");
+}
+
+function applyStringConstraints(schema: JsonSchema, constraints: DtConstraint[]): void {
+  for (const constraint of constraints) {
+    switch (constraint.type) {
+      case "LENGTH":
+        if (constraint.minLength !== undefined) schema.minLength = constraint.minLength;
+        if (constraint.maxLength !== undefined) schema.maxLength = constraint.maxLength;
+        break;
+      case "NOT_BLANK":
+      case "NOT_EMPTY":
+        schema.minLength = Math.max(schema.minLength ?? 0, 1);
+        break;
+      case "NO_WHITESPACE":
+        schema.pattern = "^\\S*$";
+        break;
+      case "PATTERN":
+        if (constraint.pattern) schema.pattern = constraint.pattern;
+        break;
+    }
+  }
+}
+
+/** Translate the type of an array item (which cannot itself be a list/set) */
+export function translateItemSchema(item: DtItemDef): JsonSchema {
+  const { type, constraints = [] } = item;
+  if (isTypeRef(type)) {
+    return { $ref: translateRef(type.$ref) };
+  }
+  return translatePrimitiveSchema(type, constraints);
+}
+
+/** Translate a Dynatrace primitive type string to a JSON Schema object */
+export function translatePrimitiveSchema(dtType: string, constraints: DtConstraint[]): JsonSchema {
+  switch (dtType) {
+    case "text":
+    case "secret":
+    case "setting": {
+      const schema: JsonSchema = { type: "string" };
+      applyStringConstraints(schema, constraints);
+      return schema;
+    }
+    case "boolean":
+      return { type: "boolean" };
+    case "integer":
+      return { type: "integer" };
+    case "float":
+      return { type: "number" };
+    default:
+      // Unknown primitives treated as string to avoid breaking validation
+      return { type: "string" };
+  }
+}
+
+/** Translate a single Dynatrace property definition to a JSON Schema node */
+export function translatePropertySchema(prop: DtPropertyDef): JsonSchema {
+  const { type, constraints = [], nullable, minObjects, maxObjects, items } = prop;
+
+  let schema: JsonSchema;
+
+  if (isTypeRef(type)) {
+    schema = { $ref: translateRef(type.$ref) };
+  } else if (type === "list" || type === "set") {
+    schema = { type: "array" };
+
+    if (type === "set") schema.uniqueItems = true;
+    if (items) schema.items = translateItemSchema(items);
+
+    const hasNotEmpty = constraints.some(c => c.type === "NOT_EMPTY");
+    const effectiveMin = Math.max(hasNotEmpty ? 1 : 0, minObjects ?? 0);
+    if (effectiveMin > 0) schema.minItems = effectiveMin;
+    if (maxObjects !== undefined && maxObjects > 1) schema.maxItems = maxObjects;
+  } else {
+    schema = translatePrimitiveSchema(type, constraints);
+  }
+
+  // Wrap nullable types so the field can also be explicitly set to null
+  if (nullable) {
+    schema = { anyOf: [schema, { type: "null" }] };
+  }
+
+  return schema;
+}
+
+function translateProperties(dtProps: Record<string, DtPropertyDef>): Record<string, JsonSchema> {
+  const properties: Record<string, JsonSchema> = {};
+  for (const [key, prop] of Object.entries(dtProps)) {
+    properties[key] = translatePropertySchema(prop);
+  }
+  return properties;
+}
+
+/** Translate a Dynatrace enum definition to a JSON Schema */
+export function translateEnum(dtEnum: DtEnumDef): JsonSchema {
+  return {
+    type: "string",
+    enum: dtEnum.items.map(item => item.value),
+  };
+}
+
+/**
+ * Compute the list of unconditionally required property names.
+ * A property is required when it is non-nullable and has no precondition.
+ */
+export function computeRequiredProperties(dtProps: Record<string, DtPropertyDef>): string[] {
+  return Object.entries(dtProps)
+    .filter(([, prop]) => !prop.nullable && !prop.precondition)
+    .map(([key]) => key);
+}
+
+/** Build a JSON Schema condition block from a single Dynatrace precondition. */
+function buildConditionSchema(precondition: DtPrecondition): JsonSchema {
+  switch (precondition.type) {
+    case "EQUALS":
+      return {
+        properties: { [precondition.property]: { const: precondition.expectedValue } },
+        required: [precondition.property],
+      };
+    case "NOT":
+      return { not: buildConditionSchema(precondition.precondition) };
+    case "IN":
+      return {
+        properties: { [precondition.property]: { enum: precondition.expectedValues } },
+        required: [precondition.property],
+      };
+  }
+}
+
+/** Serialize a precondition to a stable string key for grouping. */
+function preconditionKey(precondition: DtPrecondition): string {
+  return JSON.stringify(precondition);
+}
+
+/**
+ * Build if/then conditional blocks from preconditioned properties.
+ * Properties sharing the same precondition are grouped into a single if/then.
+ */
+export function buildConditionals(dtProps: Record<string, DtPropertyDef>): JsonSchema[] {
+  const groups = new Map<string, { precondition: DtPrecondition; propNames: string[] }>();
+
+  for (const [key, prop] of Object.entries(dtProps)) {
+    if (!prop.precondition) continue;
+
+    const groupKey = preconditionKey(prop.precondition);
+    const existing = groups.get(groupKey);
+    if (existing) {
+      existing.propNames.push(key);
+    } else {
+      groups.set(groupKey, { precondition: prop.precondition, propNames: [key] });
+    }
+  }
+
+  const conditionals: JsonSchema[] = [];
+  for (const { precondition, propNames } of groups.values()) {
+    conditionals.push({
+      if: buildConditionSchema(precondition),
+      then: { required: propNames },
+    });
+  }
+
+  return conditionals;
+}
+
+/**
+ * Build a complete object schema with properties, required, additionalProperties, and conditionals.
+ */
+function buildObjectSchema(dtProps: Record<string, DtPropertyDef>): JsonSchema {
+  const schema: JsonSchema = {
+    type: "object",
+    properties: translateProperties(dtProps),
+    additionalProperties: false,
+  };
+
+  const required = computeRequiredProperties(dtProps);
+  if (required.length > 0) {
+    schema.required = required;
+  }
+
+  const conditionals = buildConditionals(dtProps);
+  if (conditionals.length > 0) {
+    schema.allOf = conditionals;
+  }
+
+  return schema;
+}
+
+/** Translate a Dynatrace complex type definition to a JSON Schema object */
+export function translateType(dtType: DtTypeDef): JsonSchema {
+  return buildObjectSchema(dtType.properties);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Translate a raw Dynatrace schema (parsed JSON) into a standard JSON Schema */
+export function translateSchema(raw: unknown): JsonSchema {
+  const dt = raw as DtSchema;
+
+  const $defs: Record<string, JsonSchema> = {};
+
+  for (const [name, dtEnum] of Object.entries(dt.enums ?? {})) {
+    $defs[name] = translateEnum(dtEnum);
+  }
+  for (const [name, dtType] of Object.entries(dt.types ?? {})) {
+    $defs[name] = translateType(dtType);
+  }
+
+  const jsonSchema: JsonSchema = {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    title: dt.displayName,
+    description: dt.description,
+    ...buildObjectSchema(dt.properties),
+  };
+
+  if (Object.keys($defs).length > 0) {
+    jsonSchema.$defs = $defs;
+  }
+
+  return jsonSchema;
+}

--- a/src/utils/openPipelineSchemaTranslation.ts
+++ b/src/utils/openPipelineSchemaTranslation.ts
@@ -41,6 +41,8 @@ export function translateRef(ref: string): string {
 }
 
 function applyStringConstraints(schema: JsonSchema, constraints: DtConstraint[]): void {
+  const patterns: string[] = [];
+
   for (const constraint of constraints) {
     switch (constraint.type) {
       case "LENGTH":
@@ -52,12 +54,18 @@ function applyStringConstraints(schema: JsonSchema, constraints: DtConstraint[])
         schema.minLength = Math.max(schema.minLength ?? 0, 1);
         break;
       case "NO_WHITESPACE":
-        schema.pattern = "^\\S*$";
+        patterns.push("^\\S*$");
         break;
       case "PATTERN":
-        if (constraint.pattern) schema.pattern = constraint.pattern;
+        if (constraint.pattern) patterns.push(constraint.pattern);
         break;
     }
+  }
+
+  if (patterns.length === 1) {
+    schema.pattern = patterns[0];
+  } else if (patterns.length > 1) {
+    schema.allOf = patterns.map(p => ({ pattern: p }));
   }
 }
 

--- a/test/unit/__tests__/utils/openPipelineSchemaTranslation.test.ts
+++ b/test/unit/__tests__/utils/openPipelineSchemaTranslation.test.ts
@@ -1,0 +1,478 @@
+import {
+  translateRef,
+  translateItemSchema,
+  translatePrimitiveSchema,
+  translatePropertySchema,
+  translateEnum,
+  translateType,
+  translateSchema,
+  computeRequiredProperties,
+  buildConditionals,
+} from "../../../../src/utils/openPipelineSchemaTranslation";
+
+describe("translateRef", () => {
+  it("converts #/types/ references to #/$defs/", () => {
+    expect(translateRef("#/types/Processor")).toBe("#/$defs/Processor");
+  });
+
+  it("converts #/enums/ references to #/$defs/", () => {
+    expect(translateRef("#/enums/ProcessorType")).toBe("#/$defs/ProcessorType");
+  });
+});
+
+describe("translatePrimitiveSchema", () => {
+  it("translates text to string", () => {
+    expect(translatePrimitiveSchema("text", [])).toEqual({ type: "string" });
+  });
+
+  it("translates boolean to boolean", () => {
+    expect(translatePrimitiveSchema("boolean", [])).toEqual({ type: "boolean" });
+  });
+
+  it("translates integer to integer", () => {
+    expect(translatePrimitiveSchema("integer", [])).toEqual({ type: "integer" });
+  });
+
+  it("translates float to number", () => {
+    expect(translatePrimitiveSchema("float", [])).toEqual({ type: "number" });
+  });
+
+  it("translates secret to string", () => {
+    expect(translatePrimitiveSchema("secret", [])).toEqual({ type: "string" });
+  });
+
+  it("translates setting to string", () => {
+    expect(translatePrimitiveSchema("setting", [])).toEqual({ type: "string" });
+  });
+
+  it("applies LENGTH constraint min and max", () => {
+    const result = translatePrimitiveSchema("text", [
+      { type: "LENGTH", minLength: 3, maxLength: 256 },
+    ]);
+    expect(result).toEqual({ type: "string", minLength: 3, maxLength: 256 });
+  });
+
+  it("applies NOT_BLANK as minLength 1", () => {
+    const result = translatePrimitiveSchema("text", [{ type: "NOT_BLANK" }]);
+    expect(result.minLength).toBe(1);
+  });
+
+  it("does not override a larger minLength set by LENGTH when NOT_BLANK is also present", () => {
+    const result = translatePrimitiveSchema("text", [
+      { type: "NOT_BLANK" },
+      { type: "LENGTH", minLength: 4 },
+    ]);
+    expect(result.minLength).toBe(4);
+  });
+
+  it("applies NO_WHITESPACE as pattern", () => {
+    const result = translatePrimitiveSchema("text", [{ type: "NO_WHITESPACE" }]);
+    expect(result.pattern).toBe("^\\S*$");
+  });
+
+  it("applies PATTERN constraint", () => {
+    const result = translatePrimitiveSchema("text", [{ type: "PATTERN", pattern: "^[a-z]+$" }]);
+    expect(result.pattern).toBe("^[a-z]+$");
+  });
+
+  it("falls back to string for unknown types", () => {
+    expect(translatePrimitiveSchema("unknown_type", [])).toEqual({ type: "string" });
+  });
+});
+
+describe("translateItemSchema", () => {
+  it("translates a primitive item", () => {
+    expect(translateItemSchema({ type: "text" })).toEqual({ type: "string" });
+  });
+
+  it("translates a $ref item", () => {
+    expect(translateItemSchema({ type: { $ref: "#/types/Processor" } })).toEqual({
+      $ref: "#/$defs/Processor",
+    });
+  });
+});
+
+describe("translatePropertySchema", () => {
+  it("translates a simple non-nullable text property", () => {
+    const result = translatePropertySchema({
+      type: "text",
+      nullable: false,
+      constraints: [{ type: "LENGTH", maxLength: 100 }],
+    });
+    expect(result).toEqual({ type: "string", maxLength: 100 });
+  });
+
+  it("wraps nullable properties with anyOf including null", () => {
+    const result = translatePropertySchema({ type: "text", nullable: true, constraints: [] });
+    expect(result).toEqual({ anyOf: [{ type: "string" }, { type: "null" }] });
+  });
+
+  it("translates list type to array with items", () => {
+    const result = translatePropertySchema({
+      type: "list",
+      nullable: false,
+      items: { type: "text" },
+      minObjects: 1,
+      maxObjects: 50,
+    });
+    expect(result).toEqual({
+      type: "array",
+      items: { type: "string" },
+      minItems: 1,
+      maxItems: 50,
+    });
+  });
+
+  it("translates set type to array with uniqueItems", () => {
+    const result = translatePropertySchema({
+      type: "set",
+      nullable: false,
+      items: { type: "text" },
+      minObjects: 0,
+      maxObjects: 10,
+    });
+    expect(result).toEqual({
+      type: "array",
+      uniqueItems: true,
+      items: { type: "string" },
+      maxItems: 10,
+    });
+  });
+
+  it("applies NOT_EMPTY constraint on lists as minItems: 1", () => {
+    const result = translatePropertySchema({
+      type: "list",
+      nullable: false,
+      constraints: [{ type: "NOT_EMPTY" }],
+      items: { type: "text" },
+    });
+    expect(result).toMatchObject({ minItems: 1 });
+  });
+
+  it("translates a $ref property", () => {
+    const result = translatePropertySchema({
+      type: { $ref: "#/types/Stage" },
+      nullable: false,
+    });
+    expect(result).toEqual({ $ref: "#/$defs/Stage" });
+  });
+
+  it("wraps a nullable $ref with anyOf", () => {
+    const result = translatePropertySchema({
+      type: { $ref: "#/types/Stage" },
+      nullable: true,
+    });
+    expect(result).toEqual({ anyOf: [{ $ref: "#/$defs/Stage" }, { type: "null" }] });
+  });
+
+  it("omits maxItems when maxObjects is 1 (single-value property)", () => {
+    const result = translatePropertySchema({
+      type: "list",
+      nullable: false,
+      items: { type: "text" },
+      maxObjects: 1,
+    });
+    expect(result).not.toHaveProperty("maxItems");
+  });
+});
+
+describe("translateEnum", () => {
+  it("produces a string enum with all values", () => {
+    const result = translateEnum({
+      type: "enum",
+      displayName: "MyEnum",
+      items: [{ value: "a" }, { value: "b" }, { value: "c" }],
+    });
+    expect(result).toEqual({ type: "string", enum: ["a", "b", "c"] });
+  });
+});
+
+describe("translateType", () => {
+  it("produces an object schema with translated properties and additionalProperties false", () => {
+    const result = translateType({
+      type: "object",
+      properties: {
+        name: { type: "text", nullable: false },
+        enabled: { type: "boolean", nullable: false },
+      },
+    });
+    expect(result.type).toBe("object");
+    expect(result.additionalProperties).toBe(false);
+    expect(result.properties?.name).toEqual({ type: "string" });
+    expect(result.properties?.enabled).toEqual({ type: "boolean" });
+  });
+
+  it("includes required array for non-nullable properties without preconditions", () => {
+    const result = translateType({
+      type: "object",
+      properties: {
+        id: { type: "text", nullable: false },
+        label: { type: "text", nullable: true },
+        conditional: {
+          type: "text",
+          nullable: false,
+          precondition: { type: "EQUALS", property: "id", expectedValue: "special" },
+        },
+      },
+    });
+    expect(result.required).toEqual(["id"]);
+  });
+
+  it("omits required array when no properties qualify", () => {
+    const result = translateType({
+      type: "object",
+      properties: {
+        optional: { type: "text", nullable: true },
+      },
+    });
+    expect(result.required).toBeUndefined();
+  });
+
+  it("includes allOf with if/then for preconditioned properties", () => {
+    const result = translateType({
+      type: "object",
+      properties: {
+        kind: { type: "text", nullable: false },
+        extra: {
+          type: "text",
+          nullable: false,
+          precondition: { type: "EQUALS", property: "kind", expectedValue: "special" },
+        },
+      },
+    });
+    expect(result.allOf).toEqual([
+      {
+        if: {
+          properties: { kind: { const: "special" } },
+          required: ["kind"],
+        },
+        then: { required: ["extra"] },
+      },
+    ]);
+  });
+});
+
+describe("translateSchema", () => {
+  const rawSchema = {
+    schemaId: "builtin:example",
+    displayName: "Example Schema",
+    description: "An example",
+    enums: {
+      Status: {
+        type: "enum",
+        displayName: "Status",
+        items: [{ value: "active" }, { value: "inactive" }],
+      },
+    },
+    types: {
+      Config: {
+        type: "object",
+        properties: {
+          enabled: { type: "boolean", nullable: false },
+        },
+      },
+    },
+    properties: {
+      name: { type: "text", nullable: false, constraints: [{ type: "LENGTH", maxLength: 100 }] },
+      status: { type: { $ref: "#/enums/Status" }, nullable: true },
+      config: { type: { $ref: "#/types/Config" }, nullable: true },
+    },
+  };
+
+  it("includes $schema, title, and description at the root", () => {
+    const result = translateSchema(rawSchema);
+    expect(result.$schema).toBe("http://json-schema.org/draft-07/schema#");
+    expect(result.title).toBe("Example Schema");
+    expect(result.description).toBe("An example");
+  });
+
+  it("includes all root properties translated correctly", () => {
+    const result = translateSchema(rawSchema);
+    expect(result.properties?.name).toEqual({ type: "string", maxLength: 100 });
+    expect(result.properties?.status).toEqual({
+      anyOf: [{ $ref: "#/$defs/Status" }, { type: "null" }],
+    });
+  });
+
+  it("sets additionalProperties to false on the root", () => {
+    const result = translateSchema(rawSchema);
+    expect(result.additionalProperties).toBe(false);
+  });
+
+  it("includes required array for non-nullable root properties without preconditions", () => {
+    const result = translateSchema(rawSchema);
+    expect(result.required).toEqual(["name"]);
+  });
+
+  it("populates $defs with translated enums and types", () => {
+    const result = translateSchema(rawSchema);
+    expect(result.$defs?.Status).toEqual({ type: "string", enum: ["active", "inactive"] });
+    expect(result.$defs?.Config).toEqual({
+      type: "object",
+      properties: { enabled: { type: "boolean" } },
+      additionalProperties: false,
+      required: ["enabled"],
+    });
+  });
+
+  it("emits allOf with if/then for root-level preconditions", () => {
+    const schemaWithPreconditions = {
+      schemaId: "builtin:cond",
+      properties: {
+        kind: { type: "text", nullable: false },
+        extra: {
+          type: "text",
+          nullable: false,
+          precondition: { type: "EQUALS", property: "kind", expectedValue: "special" },
+        },
+      },
+    };
+    const result = translateSchema(schemaWithPreconditions);
+    expect(result.allOf).toEqual([
+      {
+        if: {
+          properties: { kind: { const: "special" } },
+          required: ["kind"],
+        },
+        then: { required: ["extra"] },
+      },
+    ]);
+  });
+});
+
+describe("computeRequiredProperties", () => {
+  it("returns non-nullable properties without preconditions", () => {
+    const result = computeRequiredProperties({
+      id: { type: "text", nullable: false },
+      name: { type: "text", nullable: false },
+      label: { type: "text", nullable: true },
+    });
+    expect(result).toEqual(["id", "name"]);
+  });
+
+  it("excludes properties with preconditions", () => {
+    const result = computeRequiredProperties({
+      id: { type: "text", nullable: false },
+      conditional: {
+        type: "text",
+        nullable: false,
+        precondition: { type: "EQUALS", property: "id", expectedValue: "x" },
+      },
+    });
+    expect(result).toEqual(["id"]);
+  });
+
+  it("returns empty array when all properties are nullable", () => {
+    const result = computeRequiredProperties({
+      opt1: { type: "text", nullable: true },
+      opt2: { type: "text", nullable: true },
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("treats properties with undefined nullable as required", () => {
+    const result = computeRequiredProperties({
+      implicit: { type: "text" },
+    });
+    expect(result).toEqual(["implicit"]);
+  });
+});
+
+describe("buildConditionals", () => {
+  it("returns empty array when no preconditions exist", () => {
+    const result = buildConditionals({
+      id: { type: "text", nullable: false },
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("builds if/then for EQUALS precondition", () => {
+    const result = buildConditionals({
+      dql: {
+        type: { $ref: "#/types/DqlAttributes" },
+        nullable: false,
+        precondition: { type: "EQUALS", property: "type", expectedValue: "dql" },
+      },
+    });
+    expect(result).toEqual([
+      {
+        if: {
+          properties: { type: { const: "dql" } },
+          required: ["type"],
+        },
+        then: { required: ["dql"] },
+      },
+    ]);
+  });
+
+  it("builds if/then for NOT(EQUALS) precondition", () => {
+    const result = buildConditionals({
+      matcher: {
+        type: "text",
+        nullable: false,
+        precondition: {
+          type: "NOT",
+          precondition: { type: "EQUALS", property: "type", expectedValue: "technology" },
+        },
+      },
+    });
+    expect(result).toEqual([
+      {
+        if: {
+          not: {
+            properties: { type: { const: "technology" } },
+            required: ["type"],
+          },
+        },
+        then: { required: ["matcher"] },
+      },
+    ]);
+  });
+
+  it("groups properties sharing the same precondition", () => {
+    const sharedPrecondition = {
+      type: "EQUALS" as const,
+      property: "extractNode",
+      expectedValue: true,
+    };
+    const result = buildConditionals({
+      nodeName: {
+        type: "text",
+        nullable: false,
+        precondition: sharedPrecondition,
+      },
+      fieldsToExtract: {
+        type: "list",
+        nullable: false,
+        precondition: sharedPrecondition,
+      },
+    });
+    expect(result).toEqual([
+      {
+        if: {
+          properties: { extractNode: { const: true } },
+          required: ["extractNode"],
+        },
+        then: { required: ["nodeName", "fieldsToExtract"] },
+      },
+    ]);
+  });
+
+  it("creates separate blocks for different preconditions", () => {
+    const result = buildConditionals({
+      propA: {
+        type: "text",
+        nullable: false,
+        precondition: { type: "EQUALS", property: "kind", expectedValue: "a" },
+      },
+      propB: {
+        type: "text",
+        nullable: false,
+        precondition: { type: "EQUALS", property: "kind", expectedValue: "b" },
+      },
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].then?.required).toEqual(["propA"]);
+    expect(result[1].then?.required).toEqual(["propB"]);
+  });
+});

--- a/test/unit/__tests__/utils/openPipelineSchemaTranslation.test.ts
+++ b/test/unit/__tests__/utils/openPipelineSchemaTranslation.test.ts
@@ -75,6 +75,27 @@ describe("translatePrimitiveSchema", () => {
     expect(result.pattern).toBe("^[a-z]+$");
   });
 
+  it("uses allOf when multiple PATTERN constraints exist", () => {
+    const result = translatePrimitiveSchema("text", [
+      { type: "PATTERN", pattern: "^[a-z][a-z0-9._]{0,31}$" },
+      { type: "PATTERN", pattern: "^(?![Dd][Tt]\\.).*$" },
+    ]);
+    expect(result.pattern).toBeUndefined();
+    expect(result.allOf).toEqual([
+      { pattern: "^[a-z][a-z0-9._]{0,31}$" },
+      { pattern: "^(?![Dd][Tt]\\.).*$" },
+    ]);
+  });
+
+  it("uses allOf when NO_WHITESPACE and PATTERN are both present", () => {
+    const result = translatePrimitiveSchema("text", [
+      { type: "NO_WHITESPACE" },
+      { type: "PATTERN", pattern: "^(?![Dd][Tt]\\.).*$" },
+    ]);
+    expect(result.pattern).toBeUndefined();
+    expect(result.allOf).toEqual([{ pattern: "^\\S*$" }, { pattern: "^(?![Dd][Tt]\\.).*$" }]);
+  });
+
   it("falls back to string for unknown types", () => {
     expect(translatePrimitiveSchema("unknown_type", [])).toEqual({ type: "string" });
   });

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -1558,10 +1558,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1768,10 +1769,11 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2992,9 +2994,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
       "cpu": [
         "arm"
       ],
@@ -3006,9 +3008,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
       "cpu": [
         "arm64"
       ],
@@ -3020,9 +3022,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
       "cpu": [
         "arm64"
       ],
@@ -3034,9 +3036,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
       "cpu": [
         "x64"
       ],
@@ -3048,9 +3050,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
       "cpu": [
         "arm64"
       ],
@@ -3062,9 +3064,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
       "cpu": [
         "x64"
       ],
@@ -3076,9 +3078,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
       "cpu": [
         "arm"
       ],
@@ -3090,9 +3092,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
       "cpu": [
         "arm"
       ],
@@ -3104,9 +3106,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
       "cpu": [
         "arm64"
       ],
@@ -3118,9 +3120,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
       "cpu": [
         "arm64"
       ],
@@ -3132,9 +3134,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
       "cpu": [
         "loong64"
       ],
@@ -3146,9 +3162,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
       "cpu": [
         "ppc64"
       ],
@@ -3160,9 +3190,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
       "cpu": [
         "riscv64"
       ],
@@ -3174,9 +3204,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3188,9 +3218,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
       "cpu": [
         "s390x"
       ],
@@ -3202,9 +3232,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
       "cpu": [
         "x64"
       ],
@@ -3216,9 +3246,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
       "cpu": [
         "x64"
       ],
@@ -3229,10 +3259,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
       "cpu": [
         "arm64"
       ],
@@ -3244,9 +3288,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
       "cpu": [
         "arm64"
       ],
@@ -3258,9 +3302,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
       "cpu": [
         "ia32"
       ],
@@ -3272,9 +3316,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
       "cpu": [
         "x64"
       ],
@@ -3286,9 +3330,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
       "cpu": [
         "x64"
       ],
@@ -4208,10 +4252,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5810,10 +5855,11 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5872,10 +5918,11 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6003,10 +6050,11 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6257,10 +6305,11 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6454,10 +6503,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -6668,10 +6718,11 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -8093,12 +8144,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9306,9 +9358,9 @@
       "license": "Unlicense"
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9322,28 +9374,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
         "fsevents": "~2.3.2"
       }
     },


### PR DESCRIPTION
As described in #291 

## What Changed

<img width="753" height="285" alt="image" src="https://github.com/user-attachments/assets/3336dadd-a28c-4a38-9553-5e528076c87d" />

### New: Settings API method (`src/dynatrace-api/environment_v2/settings.ts`)

Added `getSchema(schemaId)` to the `SettingsService` class. This calls `GET /api/v2/settings/schemas/{schemaId}` to fetch a single schema definition by ID. It follows the same `HttpClient` pattern used by all other API methods in this service.

### New: OpenPipeline schema types and config (`src/interfaces/openPipelineSchemas.ts`)

A dedicated interfaces file containing:
- **Dynatrace schema types** — `DtSchema`, `DtTypeDef`, `DtEnumDef`, `DtPropertyDef`, `DtPrecondition` (and variants), `DtConstraint`, etc. These model the raw schema format returned by the Dynatrace API.
- **JSON Schema types** — `JsonSchema` interface covering the draft-07 constructs used by the translation layer.
- **Schema config constant** — `OPENPIPELINE_SCHEMA_CONFIGS` array mapping the 4 OpenPipeline schema IDs to their file patterns and output filenames.

### New: Schema translation logic (`src/utils/openPipelineSchemaTranslation.ts`)

Pure functions that convert Dynatrace schemas to JSON Schema:
- Primitive type mapping (`text` → `string`, `float` → `number`, etc.)
- Constraint translation (`LENGTH`, `NOT_BLANK`, `PATTERN`, etc.)
- `$ref` path rewriting (`#/types/` and `#/enums/` → `#/$defs/`)
- Nullable wrapping via `anyOf`
- `required` property computation (non-nullable props without preconditions)
- `if/then` conditional generation from Dynatrace `precondition` fields (`EQUALS`, `NOT`, `IN`)
- `additionalProperties: false` enforcement on all object schemas

All functions are stateless with no I/O dependencies.

### Updated: Load schemas command (`src/commandPalette/loadSchemas.ts`)

- **`configureOpenPipelineJSONSchemas()`** — Rewritten to use the config-driven schema mappings with proper file patterns (`**/openpipeline/*metrics.pipeline.json`, etc.) instead of the previous overly broad patterns (`*.pipeline.json`). Deduplication now filters by `"openpipeline"` in file match patterns.
- **`downloadAndConvertOpenPipelineSchemas()`** — New function that fetches each OpenPipeline schema via the Settings API, converts it in-memory, and writes the result to `globalStorage/openpipeline/`. Individual failures log a warning notification without affecting overall command success.
- **Integration into `downloadSchemaFiles()`** — OpenPipeline schemas are downloaded within the existing progress indicator, gated on schema version ≥ 1.330.0. They follow the same download lifecycle as extension schemas (no separate prompt).
- **`compareVersions()`** — Helper for numeric segment-by-segment version comparison.
- **Storage location** — Converted schemas are written to a dedicated `openpipeline/` folder in global storage (unversioned, always latest) instead of the version-specific folder used for extension YAML schemas.

### New: Translation tests (`test/unit/__tests__/utils/openPipelineSchemaTranslation.test.ts`)

30 test cases ported from the POC covering:
- `translateRef`, `translatePrimitiveSchema`, `translateItemSchema`
- `translatePropertySchema` (nullable, lists, sets, refs, constraints)
- `translateEnum`, `translateType`, `translateSchema` (full integration)
- `computeRequiredProperties`, `buildConditionals` (EQUALS, NOT, IN, grouped preconditions)

API-call and filesystem tests were intentionally not ported per project guidance.

## Reviewer Notes

- No existing functionality was removed or broken — the YAML schema loading flow is untouched.
- The `package-lock.json` changes are from `npm install` resolving updated transitive dependency versions; no `package.json` dependencies were added or changed.
- Existing OpenPipeline interfaces in `extensionDocs.ts` and `extensionMeta.ts` are unrelated (runtime document types) and remain unchanged.
