### PR TITLE
Adapt convertion script to match openpipeline settings 2.0 schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "extensions@dynatrace.com",
     "url": "https://info.dynatrace.com/global_all_wp_dynatrace_services_platform_extensions_fact_sheet_13656_fulfillment.html"
   },
-  "version": "2.11.0",
+  "version": "2.11.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/dynatrace-extensions/dynatrace-extensions-vscode.git"

--- a/src/commandPalette/convertTopology.ts
+++ b/src/commandPalette/convertTopology.ts
@@ -206,6 +206,7 @@ export const convertTopologyToOpenPipeline = async (
     const customId = `${cleanedName}-metrics`;
     const displayName = `ext:${cleanedName}`;
     pipelineDocs.metricPipeline = {
+      metadataList: [],
       customId,
       displayName,
     };
@@ -241,6 +242,7 @@ export const convertTopologyToOpenPipeline = async (
     const customId = `${cleanedName}-logs`;
     const displayName = `ext:${cleanedName}`;
     pipelineDocs.logPipeline = {
+      metadataList: [],
       customId,
       displayName,
     };
@@ -491,6 +493,7 @@ const createSmartscapeEdgeProcessor = (
     type: "smartscapeEdge",
     matcher,
     description,
+    enabled: true,
     smartscapeEdge: {
       sourceType,
       sourceIdFieldName: `dt.smartscape.${sourceType.toLowerCase()}`,
@@ -1002,13 +1005,17 @@ const createSmartscapeNodeProcessor = (
     type: "smartscapeNode",
     matcher,
     description,
+    enabled: true,
     smartscapeNode: {
       nodeType: newName,
       nodeIdFieldName: `dt.smartscape.${newName.toLowerCase()}`,
       idComponents,
       extractNode,
       nodeName,
-      fieldsToExtract: fieldsToExtract.length > 0 ? fieldsToExtract : undefined,
+      ...(extractNode && {
+        fieldsToExtract,
+        staticEdgesToExtract: [],
+      }),
     },
   };
 };
@@ -1095,8 +1102,13 @@ export const writePipelineSourceToFile = (
     const scopeSuffix = scope === "logs" ? "-logs" : "-metrics";
     const cleanedName = cleanExtensionName(extension.name);
     const source = {
+      metadataList: [],
       displayName: `ext:${cleanedName}`,
+      sourceType: "extension",
+      source: extension.name,
+      enabled: true,
       staticRouting: {
+        pipelineType: "custom",
         pipelineId: `${cleanedName}${scopeSuffix}`,
       },
     };

--- a/src/interfaces/extensionDocs.ts
+++ b/src/interfaces/extensionDocs.ts
@@ -137,7 +137,8 @@ export interface OpenPipelineProcessor {
   id: string;
   type: string;
   matcher: string;
-  description?: string;
+  description: string;
+  enabled: boolean;
   smartscapeNode?: OpenPipelineSmartscapeNode;
   smartscapeEdge?: OpenPipelineSmartscapeEdge;
 }
@@ -147,6 +148,7 @@ export interface OpenPipelineStage {
 }
 
 export interface OpenPipelinePipeline {
+  metadataList: unknown[];
   customId: string;
   displayName: string;
   processing?: OpenPipelineStage;
@@ -157,10 +159,15 @@ export interface OpenPipelinePipeline {
 }
 
 export interface OpenPipelineSource {
+  metadataList: unknown[];
   displayName: string;
+  sourceType: string;
+  source?: string;
+  enabled: boolean;
   defaultBucket?: string;
   processing?: OpenPipelineStage;
   staticRouting?: {
+    pipelineType: string;
     pipelineId: string;
   };
 }


### PR DESCRIPTION
The conversion script now strictly follows the schema, so that converting an existing extension does not cause warnings/problems in vscode.

I've tested this with two different extensions.

I had concerns about setting an empty array for metadataList, but that doesn't matter and it is overwritten by the cluster when the extension is uploaded