### PR TITLE
Smartscape - add primary tags, primary fields and code lens for it

### DIFF
--- a/common/commands.ts
+++ b/common/commands.ts
@@ -12,7 +12,8 @@ function createCommands<T extends string, U extends Record<string, string>>(
 }
 
 export const CodeLensCommand = createCommands("dynatrace-extensions.codelens", {
-  ScrapeMetrics: "scrapeMetrics",
+  JmxScrapeMetrics: "jmx.scrapeMetrics",
+  PrometheusScrapeMetrics: "prometheus.scrapeMetrics",
   ImportMib: "importMib",
   RunWMIQuery: "runWMIQuery",
   ValidateSelector: "validateSelector",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "extensions@dynatrace.com",
     "url": "https://info.dynatrace.com/global_all_wp_dynatrace_services_platform_extensions_fact_sheet_13656_fulfillment.html"
   },
-  "version": "2.11.2",
+  "version": "2.12.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/dynatrace-extensions/dynatrace-extensions-vscode.git"

--- a/src/codeActions/openpipelineFixes.ts
+++ b/src/codeActions/openpipelineFixes.ts
@@ -1,0 +1,228 @@
+/**
+  Copyright 2026 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import vscode from "vscode";
+import { OPENPIPELINE_MISSING_GRAIL_FIELD, OPENPIPELINE_MISSING_TAGS_FIELD } from "../constants";
+import { OpenPipelineFieldsToExtract } from "../interfaces/extensionDocs";
+import { getDiagnostics } from "../utils/diagnostics";
+import { createSingletonProvider } from "../utils/singleton";
+
+const TAGS_FIELD: OpenPipelineFieldsToExtract = {
+  referencedFieldName: "primary_tags.",
+  strategy: "startsWith",
+};
+
+// Diagnostic message format: '... missing a Grail primary field extraction: "<field>"'
+const extractGrailFieldFromMessage = (message: string): string | null => {
+  const m = message.match(/:\s*"([^"]+)"/);
+  return m ? m[1] : null;
+};
+
+// Find the next '[' at or after startOffset and return the range up to its matching ']'.
+const findArrayRange = (
+  text: string,
+  startOffset: number,
+): { start: number; end: number } | null => {
+  let i = startOffset;
+  while (i < text.length && text[i] !== "[") i++;
+  if (i >= text.length) return null;
+  const start = i;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "[") depth++;
+    else if (ch === "]") {
+      depth--;
+      if (depth === 0) return { start, end: i + 1 };
+    }
+  }
+  return null;
+};
+
+// Insert a missing field while keeping every startsWith-strategy entry at the end.
+const insertField = (
+  fields: OpenPipelineFieldsToExtract[],
+  missing: OpenPipelineFieldsToExtract,
+): OpenPipelineFieldsToExtract[] => {
+  const result = [...fields];
+  if (missing.strategy === "startsWith") {
+    result.push(missing);
+    return result;
+  }
+  let insertAt = result.length;
+  while (insertAt > 0 && result[insertAt - 1].strategy === "startsWith") {
+    insertAt--;
+  }
+  result.splice(insertAt, 0, missing);
+  return result;
+};
+
+// Re-indent JSON.stringify output so that line 0 sits at the existing '[' position
+// and every subsequent line is prefixed with the array's base indent.
+const serializeFields = (fields: OpenPipelineFieldsToExtract[], baseIndent: string): string => {
+  const raw = JSON.stringify(fields, null, 2);
+  return raw
+    .split("\n")
+    .map((line, i) => (i === 0 ? line : baseIndent + line))
+    .join("\n");
+};
+
+class OpenPipelineFixProvider implements vscode.CodeActionProvider {
+  provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range | vscode.Selection,
+  ): vscode.CodeAction[] {
+    const diagnostics = getDiagnostics(document.uri).filter(
+      d =>
+        d.code === OPENPIPELINE_MISSING_TAGS_FIELD.code ||
+        d.code === OPENPIPELINE_MISSING_GRAIL_FIELD.code,
+    );
+    if (diagnostics.length === 0) return [];
+
+    // Group diagnostics by line (each group targets one processor's fieldsToExtract).
+    const byLine = new Map<number, vscode.Diagnostic[]>();
+    for (const d of diagnostics) {
+      const line = d.range.start.line;
+      const existing = byLine.get(line);
+      if (existing) existing.push(d);
+      else byLine.set(line, [d]);
+    }
+
+    const fixActions: vscode.CodeAction[] = [];
+    for (const [line, lineDiags] of byLine) {
+      if (range.start.line !== line) continue;
+
+      for (const d of lineDiags) {
+        const fix = this.buildFix(document, d);
+        if (fix) fixActions.push(fix);
+      }
+
+      if (lineDiags.length > 1) {
+        const combined = this.buildCombinedFix(document, lineDiags);
+        if (combined) fixActions.push(combined);
+      }
+    }
+
+    return fixActions;
+  }
+
+  private buildFix(
+    document: vscode.TextDocument,
+    diagnostic: vscode.Diagnostic,
+  ): vscode.CodeAction | null {
+    const missing = this.missingFieldFor(diagnostic);
+    if (!missing) return null;
+    const edit = this.makeEdit(document, diagnostic.range.start.line, [missing]);
+    if (!edit) return null;
+
+    const title =
+      diagnostic.code === OPENPIPELINE_MISSING_TAGS_FIELD.code
+        ? 'Add "primary_tags." field extraction'
+        : `Add "${missing.referencedFieldName}" field extraction`;
+    const action = new vscode.CodeAction(title, vscode.CodeActionKind.QuickFix);
+    action.diagnostics = [diagnostic];
+    action.edit = edit;
+    return action;
+  }
+
+  private buildCombinedFix(
+    document: vscode.TextDocument,
+    diagnostics: vscode.Diagnostic[],
+  ): vscode.CodeAction | null {
+    const missing = diagnostics
+      .map(d => this.missingFieldFor(d))
+      .filter((f): f is OpenPipelineFieldsToExtract => f !== null);
+    if (missing.length === 0) return null;
+
+    const edit = this.makeEdit(document, diagnostics[0].range.start.line, missing);
+    if (!edit) return null;
+
+    const action = new vscode.CodeAction(
+      "Add all missing primary field extractions",
+      vscode.CodeActionKind.QuickFix,
+    );
+    action.diagnostics = diagnostics;
+    action.edit = edit;
+    return action;
+  }
+
+  private missingFieldFor(diagnostic: vscode.Diagnostic): OpenPipelineFieldsToExtract | null {
+    if (diagnostic.code === OPENPIPELINE_MISSING_TAGS_FIELD.code) {
+      return TAGS_FIELD;
+    }
+    if (diagnostic.code === OPENPIPELINE_MISSING_GRAIL_FIELD.code) {
+      const message = typeof diagnostic.message === "string" ? diagnostic.message : "";
+      const fieldName = extractGrailFieldFromMessage(message);
+      if (!fieldName) return null;
+      return { fieldName, referencedFieldName: fieldName };
+    }
+    return null;
+  }
+
+  private makeEdit(
+    document: vscode.TextDocument,
+    fieldsLine: number,
+    missing: OpenPipelineFieldsToExtract[],
+  ): vscode.WorkspaceEdit | null {
+    const text = document.getText();
+    const lineStartOffset = document.offsetAt(new vscode.Position(fieldsLine, 0));
+    const arrayRange = findArrayRange(text, lineStartOffset);
+    if (!arrayRange) return null;
+
+    const arrayText = text.slice(arrayRange.start, arrayRange.end);
+    let fields: OpenPipelineFieldsToExtract[];
+    try {
+      fields = JSON.parse(arrayText) as OpenPipelineFieldsToExtract[];
+    } catch {
+      return null;
+    }
+
+    let next = fields;
+    for (const m of missing) next = insertField(next, m);
+
+    const lineText = document.lineAt(fieldsLine).text;
+    const baseIndent = /^\s*/.exec(lineText)?.[0] ?? "";
+    const serialized = serializeFields(next, baseIndent);
+
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(
+      document.uri,
+      new vscode.Range(document.positionAt(arrayRange.start), document.positionAt(arrayRange.end)),
+      serialized,
+    );
+    return edit;
+  }
+}
+
+export const getOpenPipelineFixProvider = createSingletonProvider(OpenPipelineFixProvider);

--- a/src/codeLens/jmxWizard.ts
+++ b/src/codeLens/jmxWizard.ts
@@ -41,7 +41,10 @@ class JmxWizardCodeLensProvider implements vscode.CodeLensProvider {
   public readonly onDidChangeCodeLenses = this._onDidChangeCodeLenses.event;
 
   constructor() {
-    vscode.commands.registerCommand(CodeLensCommand.ScrapeMetrics, this.scrapeMetrics.bind(this));
+    vscode.commands.registerCommand(
+      CodeLensCommand.JmxScrapeMetrics,
+      this.scrapeMetrics.bind(this),
+    );
   }
 
   /**
@@ -70,7 +73,7 @@ class JmxWizardCodeLensProvider implements vscode.CodeLensProvider {
     const actionLens = new vscode.CodeLens(range, {
       title: "Navigate MBeans",
       tooltip: "Connect to a Java process and capture its MBeans, then use them in the Extension.",
-      command: CodeLensCommand.ScrapeMetrics,
+      command: CodeLensCommand.JmxScrapeMetrics,
       arguments: [],
     });
 

--- a/src/codeLens/prometheusScraper.ts
+++ b/src/codeLens/prometheusScraper.ts
@@ -73,7 +73,10 @@ class PrometheusCodeLensProvider implements vscode.CodeLensProvider {
   constructor() {
     this.codeLenses = [];
     this.regex = /^(prometheus:)/gm;
-    vscode.commands.registerCommand(CodeLensCommand.ScrapeMetrics, this.scrapeMetrics.bind(this));
+    vscode.commands.registerCommand(
+      CodeLensCommand.PrometheusScrapeMetrics,
+      this.scrapeMetrics.bind(this),
+    );
   }
 
   /**
@@ -105,7 +108,7 @@ class PrometheusCodeLensProvider implements vscode.CodeLensProvider {
             title: "Scrape data",
             tooltip:
               "Connect to an exporter or read a file and scrape metrics, then use them in the Extension.",
-            command: CodeLensCommand.ScrapeMetrics,
+            command: CodeLensCommand.PrometheusScrapeMetrics,
             arguments: [],
           }),
         );
@@ -115,7 +118,7 @@ class PrometheusCodeLensProvider implements vscode.CodeLensProvider {
             new vscode.CodeLens(range, {
               title: "Edit config",
               tooltip: "Make changes to the scraping configuration.",
-              command: CodeLensCommand.ScrapeMetrics,
+              command: CodeLensCommand.PrometheusScrapeMetrics,
               arguments: [true],
             }),
           );

--- a/src/commandPalette/convertTopology.ts
+++ b/src/commandPalette/convertTopology.ts
@@ -983,13 +983,41 @@ const createSmartscapeNodeProcessor = (
     return true;
   });
 
+  // Fields always extracted for cloud/platform context
+  const GRAIL_PRIMARY_FIELDS = [
+    "aws.account.id",
+    "aws.region",
+    "azure.location",
+    "azure.resource.group",
+    "azure.subscription",
+    "dt.host_group.id",
+    "gcp.project.id",
+    "gcp.region",
+    "k8s.cluster.name",
+    "k8s.namespace.name",
+  ];
+
   // Build fields to extract from attributes, filtering out blocked fields
-  const fieldsToExtract = (rule.attributes ?? [])
-    .filter(attr => !BLOCKED_FIELDS.includes(attr.key))
-    .map(attr => ({
-      fieldName: attr.key,
-      referencedFieldName: extractFieldNameFromPattern(attr.pattern),
-    }));
+  const fieldsToExtract = [
+    // Tag extraction using prefix strategy
+    {
+      fieldName: null,
+      referencedFieldName: "primary_tags.",
+      extractionStrategy: "STARTS_WITH",
+    },
+    // Standard platform/cloud context fields
+    ...GRAIL_PRIMARY_FIELDS.map(field => ({
+      fieldName: field,
+      referencedFieldName: field,
+    })),
+    // Fields from rule attributes, filtering out blocked fields
+    ...(rule.attributes ?? [])
+      .filter(attr => !BLOCKED_FIELDS.includes(attr.key))
+      .map(attr => ({
+        fieldName: attr.key,
+        referencedFieldName: extractFieldNameFromPattern(attr.pattern),
+      })),
+  ];
 
   const processorId = `${newName}_${extractNode ? "node" : "entity"}_${source.sourceType}_${counter}`;
 

--- a/src/commandPalette/convertTopology.ts
+++ b/src/commandPalette/convertTopology.ts
@@ -999,12 +999,6 @@ const createSmartscapeNodeProcessor = (
 
   // Build fields to extract from attributes, filtering out blocked fields
   const fieldsToExtract = [
-    // Tag extraction using prefix strategy
-    {
-      fieldName: null,
-      referencedFieldName: "primary_tags.",
-      extractionStrategy: "STARTS_WITH",
-    },
     // Standard platform/cloud context fields
     ...GRAIL_PRIMARY_FIELDS.map(field => ({
       fieldName: field,
@@ -1017,6 +1011,11 @@ const createSmartscapeNodeProcessor = (
         fieldName: attr.key,
         referencedFieldName: extractFieldNameFromPattern(attr.pattern),
       })),
+    // Tag extraction using prefix strategy
+    {
+      referencedFieldName: "primary_tags.",
+      strategy: "startsWith",
+    },
   ];
 
   const processorId = `${newName}_${extractNode ? "node" : "entity"}_${source.sourceType}_${counter}`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,12 @@ export const ACTIVATION_SCHEMA_DOC_SELECTOR: vscode.DocumentSelector = {
   pattern: "**/extension/activationSchema.json",
 };
 
+// Document selector for OpenPipeline pipeline JSON files
+export const OPENPIPELINE_DOC_SELECTOR: vscode.DocumentSelector = {
+  language: "json",
+  pattern: "**/openpipeline/*.pipeline.json",
+};
+
 export const QUICK_FIX_PROVIDER_METADATA: vscode.CodeActionProviderMetadata = {
   providedCodeActionKinds: [vscode.CodeActionKind.QuickFix],
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -167,7 +167,7 @@ export const OPENPIPELINE_MISSING_TAGS_FIELD: ExtensionDiagnosticDto = {
   code: "DED022",
   severity: vscode.DiagnosticSeverity.Warning,
   message:
-    'Node extraction processor is missing a "primary_tags." field extraction with STARTS_WITH strategy. ' +
+    'Node extraction processor is missing a "primary_tags." field extraction with startsWith strategy. ' +
     "Tags will not be propagated to this entity type.",
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -162,3 +162,17 @@ export const REFERENCED_VAR_NOT_DEFINED: ExtensionDiagnosticDto = {
   severity: vscode.DiagnosticSeverity.Error,
   message: "A variable is referenced but is not defined.",
 };
+
+export const OPENPIPELINE_MISSING_TAGS_FIELD: ExtensionDiagnosticDto = {
+  code: "DED022",
+  severity: vscode.DiagnosticSeverity.Warning,
+  message:
+    'Node extraction processor is missing a "primary_tags." field extraction with STARTS_WITH strategy. ' +
+    "Tags will not be propagated to this entity type.",
+};
+
+export const OPENPIPELINE_MISSING_GRAIL_FIELD: ExtensionDiagnosticDto = {
+  code: "DED023",
+  severity: vscode.DiagnosticSeverity.Warning,
+  message: "Node extraction processor is missing a required Grail primary field extraction.",
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import vscode from "vscode";
 import { getActivationSchemaActionProvider } from "./codeActions/activationSchema";
 import { getDiagnosticFixProvider } from "./codeActions/diagnosticFixProvider";
 import { getJMXActionProvider } from "./codeActions/jmxWizard";
+import { getOpenPipelineFixProvider } from "./codeActions/openpipelineFixes";
 import { getPrometheusActionProvider } from "./codeActions/prometheus";
 import { getSnippetGenerator } from "./codeActions/snippetGenerator";
 import { getSnmpActionProvider } from "./codeActions/snmp";
@@ -55,6 +56,7 @@ import { uploadExtensionWorkflow } from "./commandPalette/uploadExtension";
 import {
   ACTIVATION_SCHEMA_DOC_SELECTOR,
   MANIFEST_DOC_SELECTOR,
+  OPENPIPELINE_DOC_SELECTOR,
   QUICK_FIX_PROVIDER_METADATA,
   TEMP_CONFIG_DOC_SELECTOR,
 } from "./constants";
@@ -231,6 +233,7 @@ const registerCodeActionsProviders = () => [
   registerCodeActionsProvider(getJMXActionProvider()),
   registerCodeActionsProvider(getDiagnosticFixProvider()),
   registerCodeActionsProvider(getActivationSchemaActionProvider(), ACTIVATION_SCHEMA_DOC_SELECTOR),
+  registerCodeActionsProvider(getOpenPipelineFixProvider(), OPENPIPELINE_DOC_SELECTOR),
 ];
 
 const registerCodeActionsProvider = (

--- a/src/interfaces/extensionDocs.ts
+++ b/src/interfaces/extensionDocs.ts
@@ -93,8 +93,9 @@ interface AlertStrategy {
 }
 
 export interface OpenPipelineFieldsToExtract {
-  fieldName: string;
+  fieldName: string | null;
   referencedFieldName: string;
+  extractionStrategy?: string;
 }
 
 export interface OpenPipelineIdComponent {

--- a/src/interfaces/extensionDocs.ts
+++ b/src/interfaces/extensionDocs.ts
@@ -93,7 +93,7 @@ interface AlertStrategy {
 }
 
 export interface OpenPipelineFieldsToExtract {
-  fieldName: string | null;
+  fieldName?: string;
   referencedFieldName: string;
   strategy?: string;
 }

--- a/src/interfaces/extensionDocs.ts
+++ b/src/interfaces/extensionDocs.ts
@@ -95,7 +95,7 @@ interface AlertStrategy {
 export interface OpenPipelineFieldsToExtract {
   fieldName: string | null;
   referencedFieldName: string;
-  extractionStrategy?: string;
+  strategy?: string;
 }
 
 export interface OpenPipelineIdComponent {

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -39,7 +39,6 @@ import {
   REFERENCED_VAR_NOT_DEFINED,
 } from "../constants";
 import { ExtensionStub } from "../interfaces/extensionMeta";
-import { diagnoseOpenPipeline } from "./openpipelineDiagnostics";
 import {
   getCachedOid,
   getCachedParsedExtension,
@@ -60,6 +59,7 @@ import {
   getNextElementIdx,
   isSameList,
 } from "../utils/yamlParsing";
+import { diagnoseOpenPipeline } from "./openpipelineDiagnostics";
 
 export interface ExtensionDiagnosticDto {
   code: string | number | { value: string | number; target: vscode.Uri } | undefined;
@@ -86,10 +86,7 @@ export const updateDiagnosticsCollection = async (document?: vscode.TextDocument
 
   // Bail early if needed
   const parsedExtension = getCachedParsedExtension();
-  if (
-    !parsedExtension ||
-    !config.get("diagnostics")
-  ) {
+  if (!parsedExtension || !config.get("diagnostics")) {
     getDiagnosticsCollection().set(document.uri, []);
     return;
   }

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -39,6 +39,7 @@ import {
   REFERENCED_VAR_NOT_DEFINED,
 } from "../constants";
 import { ExtensionStub } from "../interfaces/extensionMeta";
+import { diagnoseOpenPipeline } from "./openpipelineDiagnostics";
 import {
   getCachedOid,
   getCachedParsedExtension,
@@ -70,13 +71,24 @@ export interface ExtensionDiagnosticDto {
  * Collects Extension 2.0 diagnostics and updates the collection managed by this module.
  */
 export const updateDiagnosticsCollection = async (document?: vscode.TextDocument) => {
-  if (!document?.fileName.endsWith("extension.yaml")) return;
+  if (!document) return;
+
+  const config = vscode.workspace.getConfiguration("dynatraceExtensions", null);
+
+  // Handle OpenPipeline pipeline files independently of extension.yaml diagnostics
+  if (document.fileName.endsWith(".pipeline.json")) {
+    const enabled = config.get<boolean>("diagnostics.all") ?? true;
+    getDiagnosticsCollection().set(document.uri, enabled ? diagnoseOpenPipeline(document) : []);
+    return;
+  }
+
+  if (!document.fileName.endsWith("extension.yaml")) return;
 
   // Bail early if needed
   const parsedExtension = getCachedParsedExtension();
   if (
     !parsedExtension ||
-    !vscode.workspace.getConfiguration("dynatraceExtensions", null).get("diagnostics")
+    !config.get("diagnostics")
   ) {
     getDiagnosticsCollection().set(document.uri, []);
     return;

--- a/src/utils/openpipelineDiagnostics.ts
+++ b/src/utils/openpipelineDiagnostics.ts
@@ -1,0 +1,167 @@
+/**
+  Copyright 2025 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import vscode from "vscode";
+import { OPENPIPELINE_MISSING_GRAIL_FIELD, OPENPIPELINE_MISSING_TAGS_FIELD } from "../constants";
+import { OpenPipelinePipeline, OpenPipelineProcessor } from "../interfaces/extensionDocs";
+import { ExtensionDiagnosticDto } from "./diagnostics";
+
+// Fields that must be present in every node extraction processor's fieldsToExtract
+// https://docs.dynatrace.com/docs/shortlink/semantic-dictionary-primary-grail-fields
+const GRAIL_PRIMARY_FIELDS = [
+  "aws.account.id",
+  "aws.region",
+  "azure.location",
+  "azure.resource.group",
+  "azure.subscription",
+  "dt.host_group.id",
+  "gcp.project.id",
+  "gcp.region",
+  "k8s.cluster.name",
+  "k8s.namespace.name",
+];
+
+/**
+ * Finds the line number in the document where a processor's id field appears.
+ * Falls back to 0 if not found.
+ */
+const findProcessorLine = (lines: string[], processorId: string): number => {
+  const searchStr = `"id": "${processorId}"`;
+  const idx = lines.findIndex(line => line.includes(searchStr));
+  return idx >= 0 ? idx : 0;
+};
+
+/**
+ * Finds the line number of the "fieldsToExtract" key within a processor's block.
+ * Searches forward from the processor's id line, stopping when another processor's
+ * id is encountered. Returns the processor line as a fallback.
+ */
+const findFieldsToExtractLine = (
+  lines: string[],
+  processorLine: number,
+  nextProcessorLine: number,
+): number => {
+  for (let i = processorLine; i < nextProcessorLine; i++) {
+    if (lines[i].includes('"fieldsToExtract"')) {
+      return i;
+    }
+  }
+  return processorLine;
+};
+
+/**
+ * Creates a vscode.Diagnostic for an OpenPipeline issue.
+ */
+const createOpenPipelineDiagnostic = (
+  lineNumber: number,
+  document: vscode.TextDocument,
+  dto: ExtensionDiagnosticDto,
+  messageOverride?: string,
+): vscode.Diagnostic => {
+  const line = document.lineAt(lineNumber);
+  const range = new vscode.Range(
+    lineNumber,
+    line.firstNonWhitespaceCharacterIndex,
+    lineNumber,
+    line.text.length,
+  );
+  return {
+    range,
+    message: messageOverride ?? dto.message,
+    code: dto.code,
+    severity: dto.severity,
+    source: "Dynatrace Extensions",
+  };
+};
+
+/**
+ * Checks a single node extraction processor for missing tag and Grail primary field extractions.
+ */
+const diagnoseNodeProcessor = (
+  processor: OpenPipelineProcessor,
+  lines: string[],
+  document: vscode.TextDocument,
+  nextProcessorLine: number,
+): vscode.Diagnostic[] => {
+  const diagnostics: vscode.Diagnostic[] = [];
+  const fieldsToExtract = processor.smartscapeNode?.fieldsToExtract ?? [];
+  const processorLine = findProcessorLine(lines, processor.id);
+  const fieldsLine = findFieldsToExtractLine(lines, processorLine, nextProcessorLine);
+
+  // Check for primary_tags. STARTS_WITH entry
+  const hasTagsField = fieldsToExtract.some(
+    f => f.referencedFieldName === "primary_tags." && f.extractionStrategy === "STARTS_WITH",
+  );
+  if (!hasTagsField) {
+    diagnostics.push(
+      createOpenPipelineDiagnostic(fieldsLine, document, OPENPIPELINE_MISSING_TAGS_FIELD),
+    );
+  }
+
+  // Check for each Grail primary field
+  for (const field of GRAIL_PRIMARY_FIELDS) {
+    const hasField = fieldsToExtract.some(f => f.referencedFieldName === field);
+    if (!hasField) {
+      diagnostics.push(
+        createOpenPipelineDiagnostic(
+          fieldsLine,
+          document,
+          OPENPIPELINE_MISSING_GRAIL_FIELD,
+          `Node extraction processor is missing a Grail primary field extraction: "${field}"`,
+        ),
+      );
+    }
+  }
+
+  return diagnostics;
+};
+
+/**
+ * Provides diagnostics for an OpenPipeline pipeline JSON file.
+ * Checks that every smartscapeNode processor with extractNode: true has:
+ *   - A "primary_tags." STARTS_WITH field extraction (for tag propagation)
+ *   - A field extraction for each of the 10 Grail primary fields
+ */
+export const diagnoseOpenPipeline = (document: vscode.TextDocument): vscode.Diagnostic[] => {
+  let pipeline: OpenPipelinePipeline;
+  try {
+    pipeline = JSON.parse(document.getText()) as OpenPipelinePipeline;
+  } catch {
+    // Invalid JSON — let the built-in JSON language server report syntax errors
+    return [];
+  }
+
+  const nodeProcessors = (pipeline.smartscapeNodeExtraction?.processors ?? []).filter(
+    p => p.type === "smartscapeNode" && p.smartscapeNode?.extractNode === true,
+  );
+
+  if (nodeProcessors.length === 0) {
+    return [];
+  }
+
+  const lines = document.getText().split("\n");
+
+  // Pre-compute line numbers for all processors to bound the search range
+  const processorLines = nodeProcessors.map(p => findProcessorLine(lines, p.id));
+
+  const diagnostics: vscode.Diagnostic[] = [];
+  for (let i = 0; i < nodeProcessors.length; i++) {
+    const nextLine = i + 1 < processorLines.length ? processorLines[i + 1] : lines.length;
+    diagnostics.push(...diagnoseNodeProcessor(nodeProcessors[i], lines, document, nextLine));
+  }
+
+  return diagnostics;
+};

--- a/src/utils/openpipelineDiagnostics.ts
+++ b/src/utils/openpipelineDiagnostics.ts
@@ -101,9 +101,9 @@ const diagnoseNodeProcessor = (
   const processorLine = findProcessorLine(lines, processor.id);
   const fieldsLine = findFieldsToExtractLine(lines, processorLine, nextProcessorLine);
 
-  // Check for primary_tags. STARTS_WITH entry
+  // Check for primary_tags. startsWith entry
   const hasTagsField = fieldsToExtract.some(
-    f => f.referencedFieldName === "primary_tags." && f.extractionStrategy === "STARTS_WITH",
+    f => f.referencedFieldName === "primary_tags." && f.strategy === "startsWith",
   );
   if (!hasTagsField) {
     diagnostics.push(


### PR DESCRIPTION
With this change, the convert smartscape command will automatically add the primary_tags and primary fields to every node extraction processor

The primary fields are hardcoded from: https://docs.dynatrace.com/docs/shortlink/semantic-dictionary-primary-grail-fields

Primary tags follow the semantic format: https://docs.dynatrace.com/docs/shortlink/semantic-dictionary-global-field-reference#primary-grail-tags-fields

I've also added code lens for it with `WARNING` for these two

---
* primary_tags
<img width="711" height="110" alt="image" src="https://github.com/user-attachments/assets/6a068292-1a4d-460a-9ba5-90b0c4630f0e" />


---
* primary fields
<img width="836" height="53" alt="image" src="https://github.com/user-attachments/assets/bf09610f-51d8-4e98-924a-b9261530f1bd" />

---


Note, this only works with a very recent dev version of Dynatrace 1.338


I also needed to cherry pick a [jmx fix for duplicate command](https://github.com/dynatrace-extensions/dynatrace-extensions-vscode/pull/298/changes/d5228af6b1b700f93fe9c9e86a851a942ac970dd) because I could not run the project from main