### PR TITLE
Add grail "important fields" and id_classic to smarrtscape converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Version 2.12.3 (15.05.2026)
+
+### 🚀 Improved in this version:
+
+- [Smartscape - add Grail important fields and id_classic to converter](https://github.com/dynatrace-extensions/dynatrace-extensions-vscode/pull/301)
+
+---
+
 ## Version 2.12.2 (05.05.2026)
 
 ### 🪲 Fixed in this version:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynatrace-extensions",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dynatrace-extensions",
-      "version": "2.12.2",
+      "version": "2.12.3",
       "dependencies": {
         "axios": "^1.15.0",
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "extensions@dynatrace.com",
     "url": "https://info.dynatrace.com/global_all_wp_dynatrace_services_platform_extensions_fact_sheet_13656_fulfillment.html"
   },
-  "version": "2.12.2",
+  "version": "2.12.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/dynatrace-extensions/dynatrace-extensions-vscode.git"

--- a/src/commandPalette/convertTopology.ts
+++ b/src/commandPalette/convertTopology.ts
@@ -1003,10 +1003,19 @@ const createSmartscapeNodeProcessor = (
     "k8s.namespace.name",
   ];
 
+  // Important fields always extracted for entity identity and cost context
+  const GRAIL_IMPORTANT_FIELDS = ["dt.security_context", "dt.cost.product", "dt.cost.costcenter"];
+
   // Build fields to extract from attributes, filtering out blocked fields
   const fieldsToExtract = [
     // Standard platform/cloud context fields
     ...GRAIL_PRIMARY_FIELDS.map(field => ({
+      fieldName: field,
+      referencedFieldName: field,
+    })),
+    // Important entity identity and cost fields
+    { fieldName: "id_classic", referencedFieldName: `dt.entity.${type.name.toLowerCase()}` },
+    ...GRAIL_IMPORTANT_FIELDS.map(field => ({
       fieldName: field,
       referencedFieldName: field,
     })),

--- a/test/unit/__tests__/commandPalette/convertTopology.test.ts
+++ b/test/unit/__tests__/commandPalette/convertTopology.test.ts
@@ -256,7 +256,7 @@ describe("convertTopology", () => {
       });
     });
 
-    it("should filter out blocked fields", async () => {
+    it("should filter out blocked fields from attributes but include them as important fields", async () => {
       if (!extension.topology?.types) {
         throw new Error("Extension topology types not found");
       }
@@ -270,11 +270,12 @@ describe("convertTopology", () => {
       const allProcessors = [...metricsProcessors, ...logsProcessors];
       allProcessors.forEach(processor => {
         const fieldsToExtract = processor.smartscapeNode?.fieldsToExtract || [];
-        const blockedFields = fieldsToExtract.filter(
+        const securityContextFields = fieldsToExtract.filter(
           (field: OpenPipelineFieldsToExtract) => field.fieldName === "dt.security_context",
         );
 
-        expect(blockedFields.length).toBe(0);
+        // dt.security_context is blocked from rule attributes but added once as an important field
+        expect(securityContextFields.length).toBe(1);
       });
     });
 

--- a/test/unit/__tests__/commandPalette/convertTopology.test.ts
+++ b/test/unit/__tests__/commandPalette/convertTopology.test.ts
@@ -269,7 +269,9 @@ describe("convertTopology", () => {
 
       const allProcessors = [...metricsProcessors, ...logsProcessors];
       allProcessors.forEach(processor => {
-        const fieldsToExtract = processor.smartscapeNode?.fieldsToExtract || [];
+        const fieldsToExtract = processor.smartscapeNode?.fieldsToExtract;
+        if (!fieldsToExtract) return; // only node-extraction processors have fieldsToExtract
+
         const securityContextFields = fieldsToExtract.filter(
           (field: OpenPipelineFieldsToExtract) => field.fieldName === "dt.security_context",
         );


### PR DESCRIPTION
This add 4 fields that were missing

  • `id_classic` -> from `dt.entity.<type_lower_case>`
  • `dt.security_context` from -> `dt.security_context`
  • `dt.cost.product` from -> `dt.cost.product`
  • `dt.cost.costcenter` from -> `dt.cost.costcenter`