### PR TITLE
VAST-680: in-editor SaaS migration guidance

### DIFF
--- a/common/commands.ts
+++ b/common/commands.ts
@@ -91,6 +91,7 @@ export const EnvironmentCommand = createCommands(EnvironmentCommandPrefix, {
   DeleteConfig: "deleteConfig",
   SaveConfig: "saveConfig",
   OpenExtension: "openExtension",
+  OpenMigrationGuide: "openMigrationGuide",
 } as const);
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type EnvironmentCommand = ObjectValues<typeof EnvironmentCommand>;

--- a/common/panels/index.ts
+++ b/common/panels/index.ts
@@ -2,6 +2,7 @@ import { ObjectValues } from "../util-types";
 import { DqlResultsPanelData } from "./dql-results-data";
 import { EmptyStatePanelData } from "./empty-state-data";
 import { MetricResultsPanelData } from "./metric-results-data";
+import { MigrationGuidePanelData } from "./migration-guide-data";
 import { SimulatorPanelData } from "./simulator-data";
 import { WmiQueryResultPanelData } from "./wmi-query-result-data";
 
@@ -10,6 +11,7 @@ export * from "./metric-results-data";
 export * from "./wmi-query-result-data";
 export * from "./empty-state-data";
 export * from "./dql-results-data";
+export * from "./migration-guide-data";
 
 /**
  * Registered data types for panels
@@ -20,6 +22,7 @@ export const PanelDataType = {
   WmiQueryResults: "WMI_RESULT",
   ExtensionSimulator: "SIMULATOR_DATA",
   DqlResults: "DQL_RESULTS",
+  MigrationGuide: "MIGRATION_GUIDE",
 } as const;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type PanelDataType = ObjectValues<typeof PanelDataType>;
@@ -32,6 +35,7 @@ export const ViewType = {
   WmiQueryResults: "dynatrace-extensions.WmiResults",
   ExtensionSimulator: "dynatrace-extensions.SimulatorUI",
   DqlQueryResults: "dynatrace-extensions.DqlResults",
+  MigrationGuide: "dynatrace-extensions.MigrationGuide",
 } as const;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type ViewType = ObjectValues<typeof ViewType>;
@@ -48,4 +52,5 @@ export type PanelData =
   | MetricResultsPanelData
   | WmiQueryResultPanelData
   | EmptyStatePanelData
-  | DqlResultsPanelData;
+  | DqlResultsPanelData
+  | MigrationGuidePanelData;

--- a/common/panels/migration-guide-data.ts
+++ b/common/panels/migration-guide-data.ts
@@ -1,0 +1,26 @@
+/**
+  Copyright 2022 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { PanelDataBase, PanelDataType } from ".";
+
+export interface MigrationGuidePanelData extends PanelDataBase {
+  dataType: typeof PanelDataType.MigrationGuide;
+  data: MigrationGuideData;
+}
+
+export interface MigrationGuideData {
+  markdown: string;
+}

--- a/package.json
+++ b/package.json
@@ -190,6 +190,11 @@
         "icon": "$(file-add)"
       },
       {
+        "command": "dynatrace-extensions-environments.openMigrationGuide",
+        "title": "Migration guide",
+        "icon": "$(book)"
+      },
+      {
         "command": "dynatrace-extensions.createMonitoringConfiguration",
         "title": "Create monitoring configuration",
         "category": "Dynatrace extensions"
@@ -654,6 +659,10 @@
           "when": "false"
         },
         {
+          "command": "dynatrace-extensions-environments.openMigrationGuide",
+          "when": "false"
+        },
+        {
           "command": "dynatrace-extensions-workspaces.enableMetricSelectors",
           "when": "false"
         },
@@ -836,17 +845,17 @@
         },
         {
           "command": "dynatrace-extensions-environments.useEnvironment",
-          "when": "view == dynatrace-extensions-environments && viewItem == dynatraceEnvironment",
+          "when": "view == dynatrace-extensions-environments && (viewItem == dynatraceEnvironment || viewItem == dynatraceEnvironmentNonCompliant)",
           "group": "inline@1"
         },
         {
           "command": "dynatrace-extensions-environments.editEnvironment",
-          "when": "view == dynatrace-extensions-environments && (viewItem == dynatraceEnvironment || viewItem == currentDynatraceEnvironment)",
+          "when": "view == dynatrace-extensions-environments && viewItem =~ /dynatraceEnvironment/",
           "group": "inline@2"
         },
         {
           "command": "dynatrace-extensions-environments.deleteEnvironment",
-          "when": "view == dynatrace-extensions-environments && (viewItem == dynatraceEnvironment || viewItem == currentDynatraceEnvironment)",
+          "when": "view == dynatrace-extensions-environments && viewItem =~ /dynatraceEnvironment/",
           "group": "inline@3"
         },
         {
@@ -873,6 +882,11 @@
           "command": "dynatrace-extensions-environments.saveConfig",
           "when": "view == dynatrace-extensions-environments && viewItem == monitoringConfiguration",
           "group": "inline@3"
+        },
+        {
+          "command": "dynatrace-extensions-environments.openMigrationGuide",
+          "when": "view == dynatrace-extensions-environments && viewItem =~ /NonCompliant$/",
+          "group": "inline"
         }
       ],
       "dynatrace-extensions.diagnostics-menu": [

--- a/src/interfaces/treeViews.ts
+++ b/src/interfaces/treeViews.ts
@@ -43,6 +43,8 @@ export interface DynatraceTenantDto {
 type TenantsTreeContextValue =
   | "dynatraceEnvironment"
   | "currentDynatraceEnvironment"
+  | "dynatraceEnvironmentNonCompliant"
+  | "currentDynatraceEnvironmentNonCompliant"
   | "monitoringConfiguration"
   | "deployedExtension";
 
@@ -59,7 +61,11 @@ export interface DynatraceTenant extends TenantsTreeItemBase {
   token: string;
   current: boolean;
   deploymentModel: DeploymentModel;
-  contextValue: "currentDynatraceEnvironment" | "dynatraceEnvironment";
+  contextValue:
+    | "currentDynatraceEnvironment"
+    | "dynatraceEnvironment"
+    | "currentDynatraceEnvironmentNonCompliant"
+    | "dynatraceEnvironmentNonCompliant";
 }
 
 export interface MonitoringConfiguration extends TenantsTreeItemBase {

--- a/src/treeViews/commands/environments.ts
+++ b/src/treeViews/commands/environments.ts
@@ -40,8 +40,8 @@ import { parseJSON } from "../../utils/jsonParsing";
 import logger from "../../utils/logging";
 import { createObjectFromSchema } from "../../utils/schemaParsing";
 import { ConfirmOption, showQuickPick, showQuickPickConfirm } from "../../utils/vscode";
-import { refreshTenantsTreeView } from "../tenantsTreeView";
 import { openMigrationGuidePanel } from "../../webviews/migrationGuide";
+import { refreshTenantsTreeView } from "../tenantsTreeView";
 
 const logTrace = ["treeViews", "commands", "environments"];
 

--- a/src/treeViews/commands/environments.ts
+++ b/src/treeViews/commands/environments.ts
@@ -41,6 +41,7 @@ import logger from "../../utils/logging";
 import { createObjectFromSchema } from "../../utils/schemaParsing";
 import { ConfirmOption, showQuickPick, showQuickPickConfirm } from "../../utils/vscode";
 import { refreshTenantsTreeView } from "../tenantsTreeView";
+import { openMigrationGuidePanel } from "../../webviews/migrationGuide";
 
 const logTrace = ["treeViews", "commands", "environments"];
 
@@ -176,6 +177,7 @@ export const registerTenantsViewCommands = () => {
           );
         }),
     ),
+    vscode.commands.registerCommand(EnvironmentCommand.OpenMigrationGuide, openMigrationGuidePanel),
   ];
 };
 

--- a/src/treeViews/tenantsTreeView.ts
+++ b/src/treeViews/tenantsTreeView.ts
@@ -144,8 +144,8 @@ export const getConnectedTenant = async () => {
   const tenant = await getTenantsTreeDataProvider()
     .getChildren()
     .then(children =>
-      children.filter(
-        (c): c is DynatraceTenant => c.contextValue.startsWith("currentDynatraceEnvironment"),
+      children.filter((c): c is DynatraceTenant =>
+        c.contextValue.startsWith("currentDynatraceEnvironment"),
       ),
     )
     .then(children => children.pop());
@@ -201,8 +201,8 @@ class TenantsTreeDataProviderImpl implements TenantsTreeDataProvider {
   constructor() {
     this.getChildren()
       .then(children =>
-        children.filter(
-          (c): c is DynatraceTenant => c.contextValue.startsWith("currentDynatraceEnvironment"),
+        children.filter((c): c is DynatraceTenant =>
+          c.contextValue.startsWith("currentDynatraceEnvironment"),
         ),
       )
       .then(children => children.pop())

--- a/src/treeViews/tenantsTreeView.ts
+++ b/src/treeViews/tenantsTreeView.ts
@@ -15,7 +15,7 @@
  */
 
 import path from "path";
-import { Utils } from "@common";
+import { EnvironmentCommand, Utils } from "@common";
 import vscode from "vscode";
 import { DynatraceClient, createDynatraceClient } from "../dynatrace-api/dynatrace";
 import {
@@ -90,7 +90,25 @@ export const checkTenantSetup = (
     }
   }
   if (issue && notify) {
-    logger.notify("WARN", `${tenant.label}: ${issue}`);
+    logger.notify("WARN", `${tenant.label}: ${issue}`, {
+      actions: [
+        {
+          title: "Edit",
+          run: async () => {
+            const treeItem = await getTenantById(tenant.id);
+            if (!treeItem) {
+              logger.warn(`Could not resolve tree item for tenant ${tenant.id}`);
+              return;
+            }
+            await vscode.commands.executeCommand(EnvironmentCommand.Edit, treeItem);
+          },
+        },
+        {
+          title: "Migration guide",
+          run: () => vscode.commands.executeCommand(EnvironmentCommand.OpenMigrationGuide),
+        },
+      ],
+    });
   }
   return issue;
 };
@@ -127,11 +145,26 @@ export const getConnectedTenant = async () => {
     .getChildren()
     .then(children =>
       children.filter(
-        (c): c is DynatraceTenant => c.contextValue === "currentDynatraceEnvironment",
+        (c): c is DynatraceTenant => c.contextValue.startsWith("currentDynatraceEnvironment"),
       ),
     )
     .then(children => children.pop());
   return tenant;
+};
+
+/**
+ * Finds a tenant tree item by its id, or undefined if not present.
+ */
+export const getTenantById = async (id: string): Promise<DynatraceTenant | undefined> => {
+  const children = await getTenantsTreeDataProvider().getChildren();
+  return children.find(
+    (c): c is DynatraceTenant =>
+      (c.contextValue === "dynatraceEnvironment" ||
+        c.contextValue === "currentDynatraceEnvironment" ||
+        c.contextValue === "dynatraceEnvironmentNonCompliant" ||
+        c.contextValue === "currentDynatraceEnvironmentNonCompliant") &&
+      c.id === id,
+  );
 };
 
 export const refreshTenantsTreeView = () => {
@@ -169,7 +202,7 @@ class TenantsTreeDataProviderImpl implements TenantsTreeDataProvider {
     this.getChildren()
       .then(children =>
         children.filter(
-          (c): c is DynatraceTenant => c.contextValue === "currentDynatraceEnvironment",
+          (c): c is DynatraceTenant => c.contextValue.startsWith("currentDynatraceEnvironment"),
         ),
       )
       .then(children => children.pop())
@@ -212,6 +245,8 @@ class TenantsTreeDataProviderImpl implements TenantsTreeDataProvider {
         // For Dynatrace Environments, Extensions are the children items
         case "dynatraceEnvironment":
         case "currentDynatraceEnvironment":
+        case "dynatraceEnvironmentNonCompliant":
+        case "currentDynatraceEnvironmentNonCompliant":
           await element.dt.extensionsV2
             .list()
             .then(list =>
@@ -287,6 +322,11 @@ const createDynatraceTenantTreeItem = (tenant: DynatraceTenantDto): DynatraceTen
   const { label, id, url, token, deploymentModel, current } = tenant;
   const dtToken = decryptToken(token);
   const [iconPath, tooltip] = getTenantIconAndTooltip(tenant);
+  const setupIssue = checkTenantSetup(tenant);
+  const baseContextValue = current ? "currentDynatraceEnvironment" : "dynatraceEnvironment";
+  const contextValue: DynatraceTenant["contextValue"] = setupIssue
+    ? `${baseContextValue}NonCompliant`
+    : baseContextValue;
   return {
     ...new vscode.TreeItem(label ?? id, vscode.TreeItemCollapsibleState.Collapsed),
     url,
@@ -296,7 +336,7 @@ const createDynatraceTenantTreeItem = (tenant: DynatraceTenantDto): DynatraceTen
     tooltip,
     current,
     deploymentModel,
-    contextValue: current ? "currentDynatraceEnvironment" : "dynatraceEnvironment",
+    contextValue,
     iconPath,
   } as DynatraceTenant;
 };

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -26,7 +26,7 @@ type NotificationLevel = Extract<LogLevel, "INFO" | "WARN" | "ERROR">;
 
 export interface NotifyAction {
   title: string;
-  run: () => void | Promise<void>;
+  run: () => void | PromiseLike<void>;
 }
 
 export interface NotifyOptions {
@@ -126,7 +126,7 @@ export const notify = (
 
   const handleSelection = (selected: string | undefined, logFn: () => void) => {
     if (selected) {
-      actions?.find(a => a.title === selected)?.run();
+      void actions?.find(a => a.title === selected)?.run();
     }
     logFn();
   };

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -23,6 +23,16 @@ import { removeOldestFiles } from "./fileSystem";
 
 type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR" | "NONE";
 type NotificationLevel = Extract<LogLevel, "INFO" | "WARN" | "ERROR">;
+
+export interface NotifyAction {
+  title: string;
+  run: () => void | Promise<void>;
+}
+
+export interface NotifyOptions {
+  trace?: string[];
+  actions?: NotifyAction[];
+}
 const CHALK_FORMATS: Record<LogLevel, string> = {
   DEBUG: chalk.white("[DEBUG]"),
   INFO: chalk.green("[INFO]"),
@@ -86,28 +96,57 @@ const getLogChannel = (() => {
 })();
 
 /**
- * Sends a notitification at the specified level to the UI. It also logs the message internally.
+ * Sends a notification at the specified level to the UI. It also logs the message internally.
+ *
+ * Accepts either the legacy spread-trace form (`...trace: string[]`) for backward compatibility,
+ * or an options object `{ trace?, actions? }` to attach clickable action buttons.
+ *
  * @param level level of the notification
  * @param message message of the notification
- * @param trace any trace breadcrumbs for internal logging
+ * @param optionsOrFirstTrace options object OR first trace breadcrumb (legacy callers)
+ * @param remainingTrace additional trace breadcrumbs (legacy callers)
  */
-export const notify = (level: NotificationLevel, message: string, ...trace: string[]) => {
+export const notify = (
+  level: NotificationLevel,
+  message: string,
+  optionsOrFirstTrace?: NotifyOptions | string,
+  ...remainingTrace: string[]
+) => {
+  let trace: string[] = [];
+  let actions: NotifyAction[] | undefined;
+
+  if (typeof optionsOrFirstTrace === "string") {
+    trace = [optionsOrFirstTrace, ...remainingTrace];
+  } else if (optionsOrFirstTrace !== undefined) {
+    trace = optionsOrFirstTrace.trace ?? [];
+    actions = optionsOrFirstTrace.actions;
+  }
+
+  const titles: string[] = actions?.map(a => a.title) ?? [];
+
+  const handleSelection = (selected: string | undefined, logFn: () => void) => {
+    if (selected) {
+      actions?.find(a => a.title === selected)?.run();
+    }
+    logFn();
+  };
+
   switch (level) {
     case "INFO":
-      vscode.window.showInformationMessage(message).then(
-        () => info(message, ...trace),
+      vscode.window.showInformationMessage(message, ...titles).then(
+        selected => handleSelection(selected, () => info(message, ...trace)),
         () => error("Could not create UI notification", ...trace),
       );
       break;
     case "WARN":
-      vscode.window.showWarningMessage(message).then(
-        () => warn(message, ...trace),
+      vscode.window.showWarningMessage(message, ...titles).then(
+        selected => handleSelection(selected, () => warn(message, ...trace)),
         () => error("Could not create UI notification", ...trace),
       );
       break;
     case "ERROR":
-      vscode.window.showErrorMessage(message).then(
-        () => error(message, ...trace),
+      vscode.window.showErrorMessage(message, ...titles).then(
+        selected => handleSelection(selected, () => error(message, ...trace)),
         () => error("Could not create UI notification", ...trace),
       );
       break;

--- a/src/webviews/migrationGuide.ts
+++ b/src/webviews/migrationGuide.ts
@@ -1,0 +1,65 @@
+/**
+  Copyright 2022 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { PanelDataType, ViewType } from "@common";
+import { renderPanel } from "./webview-utils";
+
+// Placeholder markdown — final copy to be delivered separately.
+const MIGRATION_GUIDE_MD = `
+# SaaS Migration Guide
+
+This guide covers migrating from a legacy Dynatrace SaaS setup to the current
+Platform Token authentication model.
+
+## Why migrate?
+
+Legacy SaaS URLs (e.g. \`abc12345.live.dynatrace.com\`) and legacy API tokens
+(\`dt0c01\`, \`dt0s01\`) are no longer supported for new Platform capabilities.
+Migrating enables full access to Dynatrace Platform features.
+
+## Step 1 — Update your tenant URL
+
+Your current URL uses the legacy domain. Update it to the Apps domain:
+
+- Old: \`https://abc12345.live.dynatrace.com\`
+- New: \`https://abc12345.apps.dynatrace.com\`
+
+Open the environment settings (click **Edit** on the tenant in the Environments
+tree view) and replace the URL.
+
+## Step 2 — Create a Platform Token
+
+1. In your Dynatrace environment, go to **Settings → Access tokens**.
+2. Create a new token with the required scopes for the Extensions workflow.
+3. Copy the token — it starts with \`dt0s20\`.
+
+## Step 3 — Update the token in the extension
+
+Open the environment settings (click **Edit**), replace the old token with the
+new Platform Token, and save.
+
+## Verification
+
+After saving, the warning icon on your tenant should disappear and the tenant
+should be accessible for all extension operations.
+`.trim();
+
+export const openMigrationGuidePanel = () => {
+  renderPanel(ViewType.MigrationGuide, "SaaS Migration Guide", {
+    dataType: PanelDataType.MigrationGuide,
+    data: { markdown: MIGRATION_GUIDE_MD },
+  });
+};

--- a/src/webviews/migrationGuide.ts
+++ b/src/webviews/migrationGuide.ts
@@ -19,42 +19,50 @@ import { renderPanel } from "./webview-utils";
 
 // Placeholder markdown — final copy to be delivered separately.
 const MIGRATION_GUIDE_MD = `
-# SaaS Migration Guide
+# SaaS Tenant Migration Guide
 
-This guide covers migrating from a legacy Dynatrace SaaS setup to the current
-Platform Token authentication model.
+This guide covers migrating a registered tenant connection from the Classic (legacy) Dynatrace SaaS
+setup to the latest Dynatrace Platform model.
 
 ## Why migrate?
 
-Legacy SaaS URLs (e.g. \`abc12345.live.dynatrace.com\`) and legacy API tokens
-(\`dt0c01\`, \`dt0s01\`) are no longer supported for new Platform capabilities.
-Migrating enables full access to Dynatrace Platform features.
+Classic SaaS URLs (e.g. \`abc12345.live.dynatrace.com\`) and API Access Tokens (\`dt0c01.*\`, \`dt0s01.*\`)
+are no longer supported for new Platform capabilities. Migrating enables full access to Dynatrace Platform
+features so you can make the most of this VSCode extension.
 
-## Step 1 — Update your tenant URL
+## Step 1 — Create a Platform Token
 
-Your current URL uses the legacy domain. Update it to the Apps domain:
+1. Follow the [official documentation](https://docs.dynatrace.com/docs/shortlink/platform-tokens) to create a
+Platform Token and ensure it has the following scopes:
+  - \`extensions:definitions:read\`
+  - \`extensions:definitions:write\`
+  - \`extensions:configurations:read\`
+  - \`extensions:configurations:write\`
+  - \`extensions:discovery.jmx:read\`
+  - \`storage:metrics:read\`
+  - \`storage:entities:read\`
+  - \`storage:buckets:read\`
+  - \`storage:smartscape:read\`
+  - \`settings:objects:read\`
+2. Copy the token — it will start with \`dt0s16\`
 
+## Step 2 — Update the tenant details in the extension
+
+Open the environment settings (click **Edit** on the tenant in the Environments tree view) and replace the
+non-compliant details.
+
+1. If your current URL uses the legacy domain, you must update it to the Platform domain, for example:
 - Old: \`https://abc12345.live.dynatrace.com\`
 - New: \`https://abc12345.apps.dynatrace.com\`
 
-Open the environment settings (click **Edit** on the tenant in the Environments
-tree view) and replace the URL.
+2. Replace the old token with the new Platform Token created in Step 1
 
-## Step 2 — Create a Platform Token
-
-1. In your Dynatrace environment, go to **Settings → Access tokens**.
-2. Create a new token with the required scopes for the Extensions workflow.
-3. Copy the token — it starts with \`dt0s20\`.
-
-## Step 3 — Update the token in the extension
-
-Open the environment settings (click **Edit**), replace the old token with the
-new Platform Token, and save.
+3. Continue through the remaining steps to save the updated details
 
 ## Verification
 
-After saving, the warning icon on your tenant should disappear and the tenant
-should be accessible for all extension operations.
+After saving, the icon of this environment should no longer be red.
+You can now also expand the node to view a list of extensions available in the environment.
 `.trim();
 
 export const openMigrationGuidePanel = () => {

--- a/test/unit/__tests__/treeViews/tenantsTreeView.test.ts
+++ b/test/unit/__tests__/treeViews/tenantsTreeView.test.ts
@@ -1,0 +1,273 @@
+/**
+  Copyright 2022 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { EnvironmentCommand } from "@common";
+import vscode from "vscode";
+import { DynatraceTenantDto } from "../../../../src/interfaces/treeViews";
+import * as cryptography from "../../../../src/utils/cryptography";
+import * as fileSystem from "../../../../src/utils/fileSystem";
+import logger from "../../../../src/utils/logging";
+import {
+  checkTenantSetup,
+  getTenantById,
+  getTenantsTreeDataProvider,
+} from "../../../../src/treeViews/tenantsTreeView";
+
+jest.mock("../../../../src/utils/logging");
+jest.mock("../../../../src/utils/cryptography");
+jest.mock("../../../../src/utils/fileSystem");
+jest.mock("../../../../src/statusBar/connection", () => ({
+  showConnectedStatusBar: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("../../../../src/dynatrace-api/dynatrace", () => ({
+  createDynatraceClient: jest.fn().mockReturnValue({}),
+}));
+jest.mock("../../../../src/extension", () => ({
+  getActivationContext: jest.fn().mockReturnValue({
+    logUri: { fsPath: "/mock/logs" },
+  }),
+}));
+
+const mockDecryptToken = cryptography.decryptToken as jest.MockedFunction<
+  typeof cryptography.decryptToken
+>;
+const mockGetAllTenants = fileSystem.getAllTenants as jest.MockedFunction<
+  typeof fileSystem.getAllTenants
+>;
+const mockNotify = logger.notify as jest.Mock;
+
+const buildTenant = (overrides: Partial<DynatraceTenantDto> = {}): DynatraceTenantDto => ({
+  id: "abc12345",
+  url: "https://abc12345.apps.dynatrace.com",
+  token: "encrypted-token",
+  current: false,
+  label: "My Tenant",
+  deploymentModel: "saas",
+  ...overrides,
+});
+
+describe("checkTenantSetup()", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDecryptToken.mockReturnValue("dt0s20.someplatformtoken");
+  });
+
+  describe("issue detection", () => {
+    it("returns null for a compliant saas tenant", () => {
+      const tenant = buildTenant({ url: "https://abc12345.apps.dynatrace.com" });
+      expect(checkTenantSetup(tenant)).toBeNull();
+    });
+
+    it("detects legacy live.dynatrace.com URL", () => {
+      const tenant = buildTenant({ url: "https://abc12345.live.dynatrace.com" });
+      expect(checkTenantSetup(tenant)).not.toBeNull();
+    });
+
+    it("detects legacy sprint.dynatracelabs.com URL", () => {
+      const tenant = buildTenant({ url: "https://abc12345.sprint.dynatracelabs.com" });
+      expect(checkTenantSetup(tenant)).not.toBeNull();
+    });
+
+    it("detects legacy dt0c01 token for saas tenant", () => {
+      mockDecryptToken.mockReturnValue("dt0c01.legacytoken");
+      const tenant = buildTenant({ url: "https://abc12345.apps.dynatrace.com" });
+      expect(checkTenantSetup(tenant)).not.toBeNull();
+    });
+
+    it("detects legacy dt0s01 token for saas tenant", () => {
+      mockDecryptToken.mockReturnValue("dt0s01.legacytoken");
+      const tenant = buildTenant({ url: "https://abc12345.apps.dynatrace.com" });
+      expect(checkTenantSetup(tenant)).not.toBeNull();
+    });
+
+    it("does not check token for managed tenants", () => {
+      mockDecryptToken.mockReturnValue("dt0c01.legacytoken");
+      const tenant = buildTenant({
+        url: "https://host.example.com/e/env-id",
+        deploymentModel: "managed",
+      });
+      expect(checkTenantSetup(tenant)).toBeNull();
+    });
+  });
+
+  describe("notify=true with non-compliant tenant", () => {
+    it("calls logger.notify with Edit and Migration guide actions", () => {
+      const tenant = buildTenant({ url: "https://abc12345.live.dynatrace.com" });
+
+      checkTenantSetup(tenant, true);
+
+      expect(mockNotify).toHaveBeenCalledWith(
+        "WARN",
+        expect.stringContaining("My Tenant"),
+        expect.objectContaining({
+          actions: expect.arrayContaining([
+            expect.objectContaining({ title: "Edit" }),
+            expect.objectContaining({ title: "Migration guide" }),
+          ]),
+        }),
+      );
+    });
+
+    it("Edit action dispatches EnvironmentCommand.Edit with resolved tree item", async () => {
+      const tenant = buildTenant({ url: "https://abc12345.live.dynatrace.com" });
+
+      // Set up tenant in tree so getTenantById can find it
+      mockGetAllTenants.mockReturnValue([tenant]);
+      mockDecryptToken.mockReturnValue("dt0c01.legacy");
+      (vscode.commands.executeCommand as jest.Mock).mockResolvedValue(undefined);
+
+      checkTenantSetup(tenant, true);
+
+      // Extract the Edit action from the notify call
+      const notifyOptions = mockNotify.mock.calls[0][2] as {
+        actions: { title: string; run: () => Promise<void> }[];
+      };
+      const editAction = notifyOptions.actions.find(a => a.title === "Edit");
+      expect(editAction).toBeDefined();
+
+      await editAction!.run();
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        EnvironmentCommand.Edit,
+        expect.anything(),
+      );
+    });
+
+    it("Edit action logs warn when tenant cannot be resolved", async () => {
+      const tenant = buildTenant({
+        id: "missing-id",
+        url: "https://abc12345.live.dynatrace.com",
+      });
+      mockGetAllTenants.mockReturnValue([]); // no tenants
+
+      checkTenantSetup(tenant, true);
+
+      const notifyOptions = mockNotify.mock.calls[0][2] as {
+        actions: { title: string; run: () => Promise<void> }[];
+      };
+      const editAction = notifyOptions.actions.find(a => a.title === "Edit");
+
+      await editAction!.run();
+
+      expect(logger.warn).toHaveBeenCalled();
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
+        EnvironmentCommand.Edit,
+        expect.anything(),
+      );
+    });
+
+    it("Migration guide action dispatches EnvironmentCommand.OpenMigrationGuide", async () => {
+      const tenant = buildTenant({ url: "https://abc12345.live.dynatrace.com" });
+      (vscode.commands.executeCommand as jest.Mock).mockResolvedValue(undefined);
+
+      checkTenantSetup(tenant, true);
+
+      const notifyOptions = mockNotify.mock.calls[0][2] as {
+        actions: { title: string; run: () => Promise<void> }[];
+      };
+      const guideAction = notifyOptions.actions.find(a => a.title === "Migration guide");
+
+      await guideAction!.run();
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        EnvironmentCommand.OpenMigrationGuide,
+      );
+    });
+
+    it("does not call logger.notify for compliant tenants", () => {
+      const tenant = buildTenant({ url: "https://abc12345.apps.dynatrace.com" });
+
+      checkTenantSetup(tenant, true);
+
+      expect(mockNotify).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("getTenantById()", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the matching DynatraceTenant by id", async () => {
+    const tenant = buildTenant({ id: "target-id", current: false });
+    mockDecryptToken.mockReturnValue("dt0s20.platformtoken");
+    mockGetAllTenants.mockReturnValue([tenant]);
+
+    const result = await getTenantById("target-id");
+
+    expect(result).toBeDefined();
+    expect(result?.id).toBe("target-id");
+  });
+
+  it("returns undefined when no tenant matches the id", async () => {
+    mockGetAllTenants.mockReturnValue([]);
+
+    const result = await getTenantById("nonexistent-id");
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("contextValue factory", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("assigns base contextValue for compliant non-current tenant", async () => {
+    const tenant = buildTenant({ current: false, url: "https://abc12345.apps.dynatrace.com" });
+    mockDecryptToken.mockReturnValue("dt0s20.platform");
+    mockGetAllTenants.mockReturnValue([tenant]);
+
+    const children = await getTenantsTreeDataProvider().getChildren();
+    const item = children.find(c => c.id === tenant.id);
+
+    expect(item?.contextValue).toBe("dynatraceEnvironment");
+  });
+
+  it("assigns NonCompliant suffix for non-compliant non-current tenant", async () => {
+    const tenant = buildTenant({ current: false, url: "https://abc12345.live.dynatrace.com" });
+    mockDecryptToken.mockReturnValue("dt0s20.platform");
+    mockGetAllTenants.mockReturnValue([tenant]);
+
+    const children = await getTenantsTreeDataProvider().getChildren();
+    const item = children.find(c => c.id === tenant.id);
+
+    expect(item?.contextValue).toBe("dynatraceEnvironmentNonCompliant");
+  });
+
+  it("assigns currentDynatraceEnvironmentNonCompliant for non-compliant current tenant", async () => {
+    const tenant = buildTenant({ current: true, url: "https://abc12345.live.dynatrace.com" });
+    mockDecryptToken.mockReturnValue("dt0s20.platform");
+    mockGetAllTenants.mockReturnValue([tenant]);
+
+    const children = await getTenantsTreeDataProvider().getChildren();
+    const item = children.find(c => c.id === tenant.id);
+
+    expect(item?.contextValue).toBe("currentDynatraceEnvironmentNonCompliant");
+  });
+
+  it("assigns currentDynatraceEnvironment for compliant current tenant", async () => {
+    const tenant = buildTenant({ current: true, url: "https://abc12345.apps.dynatrace.com" });
+    mockDecryptToken.mockReturnValue("dt0s20.platform");
+    mockGetAllTenants.mockReturnValue([tenant]);
+
+    const children = await getTenantsTreeDataProvider().getChildren();
+    const item = children.find(c => c.id === tenant.id);
+
+    expect(item?.contextValue).toBe("currentDynatraceEnvironment");
+  });
+});

--- a/test/unit/__tests__/utils/logging.test.ts
+++ b/test/unit/__tests__/utils/logging.test.ts
@@ -1,0 +1,151 @@
+/**
+  Copyright 2022 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import fs from "fs";
+import vscode from "vscode";
+import * as extension from "../../../../src/extension";
+import { notify } from "../../../../src/utils/logging";
+
+jest.mock("fs");
+jest.mock("../../../../src/extension");
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+const mockExtension = extension as jest.Mocked<typeof extension>;
+
+const setupMocks = () => {
+  mockExtension.getActivationContext.mockReturnValue({
+    logUri: { fsPath: "/mock/logs" },
+  } as unknown as vscode.ExtensionContext);
+  mockFs.statSync.mockReturnValue({ size: 0 } as fs.Stats);
+  mockFs.writeFileSync.mockImplementation(() => undefined);
+  mockFs.readdirSync.mockReturnValue([]);
+  (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+    get: jest.fn().mockReturnValue("INFO"),
+  });
+  (vscode.window.createOutputChannel as jest.Mock).mockReturnValue({
+    appendLine: jest.fn(),
+    dispose: jest.fn(),
+  });
+};
+
+describe("notify()", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+  });
+
+  describe("no-actions path (backward compat)", () => {
+    it("calls showWarningMessage with only the message when no actions passed", () => {
+      const mockShow = vscode.window.showWarningMessage as jest.Mock;
+      mockShow.mockResolvedValue(undefined);
+
+      notify("WARN", "test message");
+
+      expect(mockShow).toHaveBeenCalledWith("test message");
+    });
+
+    it("legacy spread-trace form passes no action titles", () => {
+      const mockShow = vscode.window.showWarningMessage as jest.Mock;
+      mockShow.mockResolvedValue(undefined);
+
+      notify("WARN", "test message", "trace1", "trace2");
+
+      expect(mockShow).toHaveBeenCalledWith("test message");
+    });
+
+    it("INFO level calls showInformationMessage", () => {
+      const mockShow = vscode.window.showInformationMessage as jest.Mock;
+      mockShow.mockResolvedValue(undefined);
+
+      notify("INFO", "info message");
+
+      expect(mockShow).toHaveBeenCalledWith("info message");
+    });
+
+    it("ERROR level calls showErrorMessage", () => {
+      const mockShow = vscode.window.showErrorMessage as jest.Mock;
+      mockShow.mockResolvedValue(undefined);
+
+      notify("ERROR", "error message");
+
+      expect(mockShow).toHaveBeenCalledWith("error message");
+    });
+  });
+
+  describe("actions path", () => {
+    it("forwards action titles to showWarningMessage", () => {
+      const mockShow = vscode.window.showWarningMessage as jest.Mock;
+      mockShow.mockResolvedValue(undefined);
+
+      notify("WARN", "test message", {
+        actions: [
+          { title: "Edit", run: jest.fn() },
+          { title: "Migration guide", run: jest.fn() },
+        ],
+      });
+
+      expect(mockShow).toHaveBeenCalledWith("test message", "Edit", "Migration guide");
+    });
+
+    it("invokes the matching action handler when a title is selected", async () => {
+      const mockRun = jest.fn().mockResolvedValue(undefined);
+      const mockShow = vscode.window.showWarningMessage as jest.Mock;
+      mockShow.mockResolvedValue("Edit");
+
+      notify("WARN", "test message", {
+        actions: [
+          { title: "Edit", run: mockRun },
+          { title: "Migration guide", run: jest.fn() },
+        ],
+      });
+
+      await Promise.resolve(); // flush the then() callback
+
+      expect(mockRun).toHaveBeenCalled();
+    });
+
+    it("does not invoke any handler when notification is dismissed", async () => {
+      const mockRun1 = jest.fn();
+      const mockRun2 = jest.fn();
+      const mockShow = vscode.window.showWarningMessage as jest.Mock;
+      mockShow.mockResolvedValue(undefined);
+
+      notify("WARN", "test message", {
+        actions: [
+          { title: "Edit", run: mockRun1 },
+          { title: "Migration guide", run: mockRun2 },
+        ],
+      });
+
+      await Promise.resolve();
+
+      expect(mockRun1).not.toHaveBeenCalled();
+      expect(mockRun2).not.toHaveBeenCalled();
+    });
+
+    it("accepts trace alongside actions", () => {
+      const mockShow = vscode.window.showWarningMessage as jest.Mock;
+      mockShow.mockResolvedValue(undefined);
+
+      notify("WARN", "test message", {
+        trace: ["traceA", "traceB"],
+        actions: [{ title: "Edit", run: jest.fn() }],
+      });
+
+      expect(mockShow).toHaveBeenCalledWith("test message", "Edit");
+    });
+  });
+});

--- a/webview-ui/src/app/App.tsx
+++ b/webview-ui/src/app/App.tsx
@@ -24,6 +24,7 @@ import { NotFound } from "./components/NotFound";
 import { DqlResultsPanel } from "./components/panels/DqlResultsPanel";
 import { ExtensionSimulator } from "./components/panels/ExtensionSimulator";
 import { MetricResultsPanel } from "./components/panels/MetricResultsPanel";
+import { MigrationGuidePanel } from "./components/panels/MigrationGuidePanel";
 import { WmiResultPanel } from "./components/panels/WmiResultPanel";
 
 interface AppProps {
@@ -51,6 +52,8 @@ const WebviewPanel = ({ panelData }: { panelData: PanelData }) => {
       return <WmiResultPanel data={data} />;
     case PanelDataType.ExtensionSimulator:
       return <ExtensionSimulator data={data} />;
+    case PanelDataType.MigrationGuide:
+      return <MigrationGuidePanel data={data} />;
     default:
       return <NotFound />;
   }

--- a/webview-ui/src/app/App.tsx
+++ b/webview-ui/src/app/App.tsx
@@ -42,10 +42,8 @@ const WebviewPanel = ({ panelData }: { panelData: PanelData }) => {
   switch (dataType) {
     case PanelDataType.Empty:
       return <NotFound />;
-    case PanelDataType.MetricResults: {
-      //const metricData = panelData;
+    case PanelDataType.MetricResults:
       return <MetricResultsPanel data={data} />;
-    }
     case PanelDataType.DqlResults:
       return <DqlResultsPanel data={data} />;
     case PanelDataType.WmiQueryResults:

--- a/webview-ui/src/app/components/panels/MigrationGuidePanel.tsx
+++ b/webview-ui/src/app/components/panels/MigrationGuidePanel.tsx
@@ -1,0 +1,32 @@
+/**
+  Copyright 2022 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { MigrationGuideData } from "@common";
+import { Markdown } from "@dynatrace/strato-components/content";
+import { Flex } from "@dynatrace/strato-components/layouts";
+import React from "react";
+
+interface MigrationGuidePanelProps {
+  data: MigrationGuideData;
+}
+
+export const MigrationGuidePanel = ({ data }: MigrationGuidePanelProps) => {
+  return (
+    <Flex flexDirection='column' gap={16}>
+      <Markdown>{data.markdown}</Markdown>
+    </Flex>
+  );
+};


### PR DESCRIPTION
## Summary

Implements VAST-680: augments the per-tenant non-compliance warning notification with two action buttons (Edit, Migration guide) and adds a new read-only `MigrationGuide` webview panel reachable from the notification and from a context-menu entry on non-compliant tenant tree nodes.

## Self-review

### Key changes

- `common/panels/migration-guide-data.ts` (new) — `MigrationGuidePanelData` contract with `{ markdown: string }` data shape.
- `common/panels/index.ts` — added `MigrationGuide` to `PanelDataType`, `ViewType`, `PanelData` union, re-export.
- `common/commands.ts` — added `EnvironmentCommand.OpenMigrationGuide`.
- `webview-ui/src/app/components/panels/MigrationGuidePanel.tsx` (new) — renders markdown via Strato `Markdown` component inside a `Flex` column.
- `webview-ui/src/app/App.tsx` — router case for `PanelDataType.MigrationGuide`.
- `src/webviews/migrationGuide.ts` (new) — placeholder markdown constant + `openMigrationGuidePanel()` calling `renderPanel`.
- `src/treeViews/commands/environments.ts` — registers `EnvironmentCommand.OpenMigrationGuide` → `openMigrationGuidePanel`.
- `src/utils/logging.ts` — `notify()` extended with backward-compatible `NotifyOptions` overload; existing spread-trace callers are unaffected. `NotifyAction.run` typed as `() => void | PromiseLike<void>` to accommodate `vscode.commands.executeCommand` return type.
- `src/treeViews/tenantsTreeView.ts` — `checkTenantSetup` attaches Edit + Migration guide action buttons; `getTenantById()` helper added; `createDynatraceTenantTreeItem` sets `NonCompliant` contextValue suffix; `getConnectedTenant` and constructor use `startsWith` for current-tenant recognition; `getChildren` switch handles non-compliant variants.
- `src/interfaces/treeViews.ts` — `TenantsTreeContextValue` and `DynatraceTenant.contextValue` extended with `*NonCompliant` variants.
- `package.json` — new `openMigrationGuide` command declaration, `commandPalette` hide entry, `view/item/context` entry for non-compliant nodes (`viewItem =~ /NonCompliant$/`), and updated `useEnvironment`/`editEnvironment`/`deleteEnvironment` when-clauses to cover non-compliant variants.

### Risk areas / things to scrutinize

- `notify()` backward-compat: the new overload detects whether the third arg is a `NotifyOptions` object or a string (first trace breadcrumb) — existing callers spreading `...fnLogTrace` continue to work because the first spread element becomes `optionsOrFirstTrace: string`.
- `startsWith("currentDynatraceEnvironment")` in `getConnectedTenant` / constructor is slightly broader than before. All non-`current` tenant contextValues start with `"dynatraceEnvironment"`, so there is no ambiguity; the only new match is `currentDynatraceEnvironmentNonCompliant`, which is correct.
- The panel serializer for `MigrationGuide` is intentionally omitted (static content; reload closes the panel — see spec).

### Test evidence

- Lint: ✅ `npm run pretest` — 0 errors
- Tests: ✅ `npm run test:unit` — 488 passed, 0 failed (20 suites)
- Webview-ui lint: ✅ `cd webview-ui && npm run lint` — 0 errors (18 pre-existing React-import warnings, same pattern as other panels)
- Smoke / manual verification: Not performed (webview-ui has no test runner; no VSCode extension host available in CI). The webview panel follows the same render path as `DqlResultsPanel`. Strato `Markdown` component confirmed available at `@dynatrace/strato-components/content`.

### Spec checklist

- [x] Common contract: `MigrationGuide` in `PanelDataType`, `ViewType`, `migration-guide-data.ts`, `PanelData` union, `EnvironmentCommand.OpenMigrationGuide` — done
- [x] Webview-ui: `MigrationGuidePanel.tsx` + App.tsx router case — done
- [x] Extension host: `migrationGuide.ts` with placeholder markdown + `openMigrationGuidePanel()` + command registration — done
- [x] Notification actions: `notify()` extended; `checkTenantSetup` attaches Edit + Migration guide buttons — done
- [x] Edit resolution: `getTenantById()` helper; Edit button resolves item and executes `EnvironmentCommand.Edit` — done
- [x] Tree gating: non-compliant contextValue variants; `startsWith` current-tenant fix; `package.json` contributions — done
- [x] Build + lint + tests pass — done
- [x] Final guide copy — intentionally deferred per Objective; placeholder markdown used

### Deviations & notes

- `NotifyAction.run` uses `PromiseLike<void>` instead of `Promise<void>` to remain compatible with `vscode.commands.executeCommand`'s `Thenable` return type without casting.
- The `view/item/context` entries for `editEnvironment` and `deleteEnvironment` were updated to use `viewItem =~ /dynatraceEnvironment/` so they remain visible on non-compliant nodes. This is a minor scope addition but necessary for UX correctness not explicitly noted in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)