### PR TITLE
VAST-755: differentiate duplicate DQL field names when merging graph chart series

### DIFF
--- a/src/utils/screenConversion.ts
+++ b/src/utils/screenConversion.ts
@@ -255,7 +255,7 @@ function convertGraphChart(
   const config = chart.graphChartConfig;
   if (!config?.metrics || config.metrics.length === 0) return null;
 
-  const dqlMetrics = graphChartMetricsToDqlInfo(config.metrics);
+  const dqlMetrics = deduplicateSeriesFieldNames(graphChartMetricsToDqlInfo(config.metrics));
   const nonDqlMetrics = config.metrics.filter(m => !m.dqlQuery);
 
   if (nonDqlMetrics.length > 0) {
@@ -584,6 +584,71 @@ const graphChartMetricsToDqlInfo = (metrics: ChartMetric[]): TimeseriesDqlInfo[]
       };
     });
 };
+
+/**
+ * Derives a clean, valid field-name base from a series' extracted name.
+ * A function expression collapses to its leading identifier (`count()` → `count`,
+ * `avg(metric.used)` → `avg`); an explicit alias is returned unchanged (`used` → `used`).
+ */
+function baseFieldName(name: string): string {
+  const parenIdx = name.indexOf("(");
+  return (parenIdx === -1 ? name : name.slice(0, parenIdx)).trim();
+}
+
+/**
+ * Removes a leading `alias =` assignment from a series expression, if present.
+ * Mirrors the alias detection in `extractMetricNames`: an `=` before the first `(`
+ * is an alias assignment; a `=` that only appears inside the expression (e.g. `==`) is not.
+ */
+function stripSeriesAlias(seriesText: string): string {
+  const eqIdx = seriesText.indexOf("=");
+  const parenIdx = seriesText.indexOf("(");
+  if (eqIdx !== -1 && (parenIdx === -1 || eqIdx < parenIdx)) {
+    return seriesText.slice(eqIdx + 1).trim();
+  }
+  return seriesText.trim();
+}
+
+/** Returns `base`, or the first free `base<n>` not already present in `used`. */
+function nextFreeName(base: string, used: Set<string>): string {
+  if (!used.has(base)) return base;
+  let i = 1;
+  while (used.has(`${base}${i}`)) i++;
+  return `${base}${i}`;
+}
+
+/**
+ * Ensures every series in a multi-metric chart exposes a unique field name before the
+ * per-metric DQL queries are merged into a single `timeseries { ... }` block.
+ *
+ * When two or more series resolve to the same field name (commonly the implicit `count`
+ * from `timeseries count()`), the merged query would redefine that field and fail on the
+ * platform. Each member of a colliding group is rewritten with an explicit, indexed alias
+ * (`count`, `count1`, `count2`, …) so the DQL is valid and the field name stays in sync with
+ * the key used in the chart's `visualization.metrics` override map. Series with already-unique
+ * names are returned untouched, so single-metric charts and non-colliding charts are unaffected.
+ */
+export function deduplicateSeriesFieldNames(metrics: TimeseriesDqlInfo[]): TimeseriesDqlInfo[] {
+  const nameCounts = new Map<string, number>();
+  for (const m of metrics) {
+    if (m.name) nameCounts.set(m.name, (nameCounts.get(m.name) ?? 0) + 1);
+  }
+
+  // Seed the used-name set with names that are already unique so generated aliases avoid them.
+  const used = new Set<string>();
+  for (const [name, count] of nameCounts) {
+    if (count === 1) used.add(name);
+  }
+
+  return metrics.map(metric => {
+    if (!metric.name || (nameCounts.get(metric.name) ?? 0) <= 1) return metric;
+
+    const uniqueName = nextFreeName(baseFieldName(metric.name), used);
+    used.add(uniqueName);
+    const expression = stripSeriesAlias(metric.seriesText ?? "");
+    return { ...metric, name: uniqueName, seriesText: `${uniqueName} = ${expression}` };
+  });
+}
 
 /**
  * Combines multiple per-metric DQL queries into a single timeseries command.

--- a/test/unit/__tests__/utils/screenConversion.test.ts
+++ b/test/unit/__tests__/utils/screenConversion.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   ConversionWarning,
   ScreenConversionContext,
+  TimeseriesDqlInfo,
 } from "../../../../src/interfaces/screenConversion";
 import {
   addWarning,
@@ -35,6 +36,7 @@ import {
   convertHealthCard,
   convertMessageCard,
   convertPropertiesCard,
+  deduplicateSeriesFieldNames,
   extractCondition,
   generateConversionReport,
   parseDqlQuery,
@@ -912,6 +914,85 @@ describe("Screen Conversion Utils", () => {
       expect(chart.dqlQuery).toContain("total=avg(memory.total)");
       expect(chart.dqlQuery).toContain("by:{host.name}");
     });
+
+    it("differentiates duplicate implicit field names with indexed aliases", () => {
+      const card: ChartsCardStub = {
+        key: "count-card",
+        charts: [
+          {
+            visualizationType: "GRAPH_CHART",
+            graphChartConfig: {
+              metrics: [
+                { metricSelector: "", dqlQuery: "timeseries count()" },
+                { metricSelector: "", dqlQuery: "timeseries count()" },
+              ],
+            },
+          },
+        ],
+      };
+
+      const warnings: ConversionWarning[] = [];
+      const [result] = convertChartsCard(minimalCtx, card, warnings, "PLATFORM");
+      const chart = defined(result).charts[0];
+
+      expect(warnings).toHaveLength(0);
+      // Each series must define a distinct field — no repeated `count`
+      expect(chart.dqlQuery).toContain("count = count()");
+      expect(chart.dqlQuery).toContain("count1 = count()");
+    });
+  });
+});
+
+// =============================================================================
+// deduplicateSeriesFieldNames
+// =============================================================================
+
+describe("deduplicateSeriesFieldNames", () => {
+  const mk = (name: string, seriesText: string): TimeseriesDqlInfo => ({
+    name,
+    seriesText,
+    dqlQuery: `timeseries ${seriesText}`,
+  });
+
+  it("leaves already-unique field names untouched", () => {
+    const input = [mk("used", "used=avg(memory.used)"), mk("total", "total=avg(memory.total)")];
+    expect(deduplicateSeriesFieldNames(input)).toEqual(input);
+  });
+
+  it("is a no-op for a single metric", () => {
+    const input = [mk("count()", "count()")];
+    expect(deduplicateSeriesFieldNames(input)).toEqual(input);
+  });
+
+  it("aliases two colliding implicit fields as base and base1", () => {
+    const input = [mk("count()", "count()"), mk("count()", "count()")];
+    const result = deduplicateSeriesFieldNames(input);
+    expect(result.map(m => m.name)).toEqual(["count", "count1"]);
+    expect(result.map(m => m.seriesText)).toEqual(["count = count()", "count1 = count()"]);
+  });
+
+  it("indexes a three-way collision as base, base1, base2", () => {
+    const input = [mk("count()", "count()"), mk("count()", "count()"), mk("count()", "count()")];
+    expect(deduplicateSeriesFieldNames(input).map(m => m.name)).toEqual([
+      "count",
+      "count1",
+      "count2",
+    ]);
+  });
+
+  it("preserves an explicit alias and only indexes the later collider", () => {
+    // `avg(count)` extracts name `avg`; the aliased `avg=...` collides on `avg`
+    const input = [mk("avg", "avg=sum(x)"), mk("avg", "avg=sum(y)")];
+    const result = deduplicateSeriesFieldNames(input);
+    expect(result.map(m => m.name)).toEqual(["avg", "avg1"]);
+    expect(result[1].seriesText).toBe("avg1 = sum(y)");
+  });
+
+  it("skips a generated name that already exists as a unique field", () => {
+    const input = [mk("count()", "count()"), mk("count()", "count()"), mk("count1", "count1=sum(x)")];
+    // `count1` is taken by the third (unique) series, so the second collider becomes `count2`
+    const result = deduplicateSeriesFieldNames(input);
+    expect(result.map(m => m.name)).toEqual(["count", "count2", "count1"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes VAST-755. During the **Convert screens** command, a multi-metric `GRAPH_CHART` is converted into a single `TIMESERIES_CHART` whose `dqlQuery` merges the per-metric DQL queries into one `timeseries { ... }` block. When two or more series resolved to the same field name (commonly the implicit `count` from `timeseries count()`), the merged query redefined the field and produced invalid DQL that fails on the platform. This makes the merge step collision-aware by aliasing colliding series with an incrementing index.

## Self-review

### Key changes
- `src/utils/screenConversion.ts` — new exported `deduplicateSeriesFieldNames()` (+ helpers `baseFieldName`, `stripSeriesAlias`, `nextFreeName`) run over the metric list in `convertGraphChart()` before `combineDqlQueries()` and the `metricOverrides` construction. Colliding series get explicit, indexed aliases (`count`, `count1`, `count2`, …); unique names are untouched.
- `test/unit/__tests__/utils/screenConversion.test.ts` — direct unit tests for the dedup helper (no-collision, single metric, 2-way, 3-way, explicit-alias collision, generated-name skip) plus an integration test through `convertChartsCard`.

### Risk areas / things to scrutinize
- Alias base derivation (`baseFieldName`) collapses a function expression to its leading identifier (`count()` → `count`). Reasonable for the observed `count` case; unusual expressions still get a unique, valid alias even if the base is coarse.
- `stripSeriesAlias` reuses the same `=`-before-`(` heuristic as `extractMetricNames`, so `==` inside an expression is not mistaken for an alias.
- Fix is scoped to the multi-metric graph-chart merge — the only site that folds multiple series into a shared field namespace.

### Test evidence
- Lint: `npm run pretest` (compile + eslint) — pass.
- Tests: `npx jest .../screenConversion.test.ts` — 81 passed (6 new).
- Smoke: covered by the `convertChartsCard` integration test exercising the full graph-chart path.

### Spec checklist
- [x] Deduplicate/alias field names when merging multi-series graph charts — `deduplicateSeriesFieldNames`.
- [x] Keep `visualization.metrics` override map keyed by the final unique names — colliding `metric.name` updated to the alias.
- [x] Evaluate other conversion functions — pie/single-value carry one metric; `dql-table` assembles a pre-built query + lookups, none merge series. No change needed.
- [x] Unit tests (collision, regression, mixed alias/implicit, 3-way, skip-taken-name).

### Deviations & notes
- Spec's Design proposed indexing only the *later* colliders and leaving the first series' text intact. Implementation instead writes an explicit alias for **every** member of a colliding group (first included, as `count = count()`). This keeps the field name identical while guaranteeing the `visualization.metrics` override key binds to the correct field for all colliders — honoring the spec's stated invariant. Non-colliding series remain untouched.