### PR TITLE
VAST-749: convert injections on base-entity screens (hosts/processes)

### DIFF
--- a/src/commandPalette/convertScreens.ts
+++ b/src/commandPalette/convertScreens.ts
@@ -64,7 +64,7 @@ import {
   extractExtensionCategory,
   extractExtensionTitle,
   generateConversionReport,
-  getBaseEntityNodeContext,
+  getBuiltinEntityNodeContext,
   resolveTarget,
   shouldSkipByTarget,
 } from "../utils/screenConversion";
@@ -155,23 +155,24 @@ async function convertScreens(options: { skipInteractive?: boolean } = {}) {
     entitiesWithScreens.includes(et),
   );
 
-  // Base entities (e.g. HOST, PROCESS_GROUP_INSTANCE) have no OpenPipeline node, so they are absent
-  // from entityToNodeMap. Their screens are injection-only: include them when they carry injections
-  // so their injection documents are still emitted (resolved via the static base-entity lookup).
-  const baseEntityTypes = [
+  // Builtin entities (e.g. HOST, PROCESS_GROUP_INSTANCE) have no OpenPipeline node, so they are
+  // absent from entityToNodeMap. Their screens are injection-only: include them when they carry
+  // injections so their injection documents are still emitted (resolved via the static builtin
+  // entity lookup).
+  const builtinEntityTypes = [
     ...new Set(
       extension.screens
         .filter(
           s =>
             !entityToNodeMap[s.entityType] &&
-            getBaseEntityNodeContext(s.entityType) !== undefined &&
+            getBuiltinEntityNodeContext(s.entityType) !== undefined &&
             ((s.detailsInjections?.length ?? 0) > 0 || (s.listInjections?.length ?? 0) > 0),
         )
         .map(s => s.entityType),
     ),
   ];
 
-  const convertibleEntityTypes = [...validEntityTypes, ...baseEntityTypes];
+  const convertibleEntityTypes = [...validEntityTypes, ...builtinEntityTypes];
   if (convertibleEntityTypes.length === 0) {
     const noValidEntitiesError =
       "No pipeline nodes match your screens' entity types. Ensure the 'id_classic' field is extracted";
@@ -214,9 +215,9 @@ async function convertScreens(options: { skipInteractive?: boolean } = {}) {
   for (const screen of extension.screens) {
     if (!selectedEntityTypes.has(screen.entityType)) continue;
 
-    const isBaseEntity = !entityToNodeMap[screen.entityType];
+    const isBuiltinEntity = !entityToNodeMap[screen.entityType];
     const resolvedNode =
-      entityToNodeMap[screen.entityType] ?? getBaseEntityNodeContext(screen.entityType);
+      entityToNodeMap[screen.entityType] ?? getBuiltinEntityNodeContext(screen.entityType);
     if (!resolvedNode) {
       logger.warn(
         `No node context for entity type "${screen.entityType}"; skipping screen`,
@@ -235,7 +236,7 @@ async function convertScreens(options: { skipInteractive?: boolean } = {}) {
       entityToNodeMap,
       conditions: Object.fromEntries(conditions.map(c => [c.id, c])),
     };
-    const result = convertSingleScreen(context, screensDir, isBaseEntity);
+    const result = convertSingleScreen(context, screensDir, isBuiltinEntity);
     results.push(result);
   }
 
@@ -364,14 +365,14 @@ const createEntityToNodeTypeMap = (
 /**
  * Converts a single screen entity type and writes all applicable JSON document files.
  *
- * For base entities (which have no OpenPipeline node) the extension does not own the entity's own
- * screen definition, so only injections are converted; any detailsSettings/listSettings present are
- * skipped with a warning.
+ * For builtin entities (which have no OpenPipeline node) the extension does not own the entity's
+ * own screen definition, so only injections are converted; any detailsSettings/listSettings
+ * present are skipped with a warning.
  */
 function convertSingleScreen(
   context: ScreenConversionContext,
   screensDir: string,
-  isBaseEntity = false,
+  isBuiltinEntity = false,
 ): ScreenConversionResult {
   const logTrace = ["commandPalette", "convertScreens", "convertSingleScreen"];
   const warnings: ConversionWarning[] = [];
@@ -381,11 +382,11 @@ function convertSingleScreen(
 
   // 4.1 detailsSettings → EntityDetailsDefinitionDocument
   if (screen.detailsSettings) {
-    if (isBaseEntity) {
+    if (isBuiltinEntity) {
       addWarning(
         warnings,
         "skipped-out-of-scope",
-        "detailsSettings skipped for base entity (extension does not own its screen definition)",
+        "detailsSettings skipped for builtin entity (extension does not own its screen definition)",
         "detailsSettings",
       );
     } else {
@@ -396,11 +397,11 @@ function convertSingleScreen(
 
   // 4.2 listSettings → InvExDefinitionDocument
   if (screen.listSettings) {
-    if (isBaseEntity) {
+    if (isBuiltinEntity) {
       addWarning(
         warnings,
         "skipped-out-of-scope",
-        "listSettings skipped for base entity (extension does not own its screen definition)",
+        "listSettings skipped for builtin entity (extension does not own its screen definition)",
         "listSettings",
       );
     } else {

--- a/src/commandPalette/convertScreens.ts
+++ b/src/commandPalette/convertScreens.ts
@@ -64,6 +64,7 @@ import {
   extractExtensionCategory,
   extractExtensionTitle,
   generateConversionReport,
+  getBaseEntityNodeContext,
   resolveTarget,
   shouldSkipByTarget,
 } from "../utils/screenConversion";
@@ -153,7 +154,25 @@ async function convertScreens(options: { skipInteractive?: boolean } = {}) {
   const validEntityTypes = Object.keys(entityToNodeMap).filter(et =>
     entitiesWithScreens.includes(et),
   );
-  if (validEntityTypes.length === 0) {
+
+  // Base entities (e.g. HOST, PROCESS_GROUP_INSTANCE) have no OpenPipeline node, so they are absent
+  // from entityToNodeMap. Their screens are injection-only: include them when they carry injections
+  // so their injection documents are still emitted (resolved via the static base-entity lookup).
+  const baseEntityTypes = [
+    ...new Set(
+      extension.screens
+        .filter(
+          s =>
+            !entityToNodeMap[s.entityType] &&
+            getBaseEntityNodeContext(s.entityType) !== undefined &&
+            ((s.detailsInjections?.length ?? 0) > 0 || (s.listInjections?.length ?? 0) > 0),
+        )
+        .map(s => s.entityType),
+    ),
+  ];
+
+  const convertibleEntityTypes = [...validEntityTypes, ...baseEntityTypes];
+  if (convertibleEntityTypes.length === 0) {
     const noValidEntitiesError =
       "No pipeline nodes match your screens' entity types. Ensure the 'id_classic' field is extracted";
     if (options?.skipInteractive) {
@@ -166,10 +185,10 @@ async function convertScreens(options: { skipInteractive?: boolean } = {}) {
 
   let selected: { label: string }[];
   if (options.skipInteractive) {
-    selected = validEntityTypes.map(et => ({ label: et }));
+    selected = convertibleEntityTypes.map(et => ({ label: et }));
   } else {
     const picked = await vscode.window.showQuickPick(
-      validEntityTypes.map(et => ({ label: et })),
+      convertibleEntityTypes.map(et => ({ label: et })),
       {
         canPickMany: true,
         placeHolder: "Select entity types to convert screens for",
@@ -195,7 +214,16 @@ async function convertScreens(options: { skipInteractive?: boolean } = {}) {
   for (const screen of extension.screens) {
     if (!selectedEntityTypes.has(screen.entityType)) continue;
 
-    const resolvedNode = entityToNodeMap[screen.entityType];
+    const isBaseEntity = !entityToNodeMap[screen.entityType];
+    const resolvedNode =
+      entityToNodeMap[screen.entityType] ?? getBaseEntityNodeContext(screen.entityType);
+    if (!resolvedNode) {
+      logger.warn(
+        `No node context for entity type "${screen.entityType}"; skipping screen`,
+        ...logTrace,
+      );
+      continue;
+    }
     const conditions = extractConditions(resolvedNode, JSON.stringify(screen, undefined, 2));
     const context: ScreenConversionContext = {
       ...resolvedNode,
@@ -207,7 +235,7 @@ async function convertScreens(options: { skipInteractive?: boolean } = {}) {
       entityToNodeMap,
       conditions: Object.fromEntries(conditions.map(c => [c.id, c])),
     };
-    const result = convertSingleScreen(context, screensDir);
+    const result = convertSingleScreen(context, screensDir, isBaseEntity);
     results.push(result);
   }
 
@@ -335,10 +363,15 @@ const createEntityToNodeTypeMap = (
 
 /**
  * Converts a single screen entity type and writes all applicable JSON document files.
+ *
+ * For base entities (which have no OpenPipeline node) the extension does not own the entity's own
+ * screen definition, so only injections are converted; any detailsSettings/listSettings present are
+ * skipped with a warning.
  */
 function convertSingleScreen(
   context: ScreenConversionContext,
   screensDir: string,
+  isBaseEntity = false,
 ): ScreenConversionResult {
   const logTrace = ["commandPalette", "convertScreens", "convertSingleScreen"];
   const warnings: ConversionWarning[] = [];
@@ -348,14 +381,32 @@ function convertSingleScreen(
 
   // 4.1 detailsSettings → EntityDetailsDefinitionDocument
   if (screen.detailsSettings) {
-    const doc = buildEntityDetailsDefinition(context, warnings);
-    if (doc) documents.push(doc);
+    if (isBaseEntity) {
+      addWarning(
+        warnings,
+        "skipped-out-of-scope",
+        "detailsSettings skipped for base entity (extension does not own its screen definition)",
+        "detailsSettings",
+      );
+    } else {
+      const doc = buildEntityDetailsDefinition(context, warnings);
+      if (doc) documents.push(doc);
+    }
   }
 
   // 4.2 listSettings → InvExDefinitionDocument
   if (screen.listSettings) {
-    const doc = buildInvExDefinition(context, warnings);
-    if (doc) documents.push(doc);
+    if (isBaseEntity) {
+      addWarning(
+        warnings,
+        "skipped-out-of-scope",
+        "listSettings skipped for base entity (extension does not own its screen definition)",
+        "listSettings",
+      );
+    } else {
+      const doc = buildInvExDefinition(context, warnings);
+      if (doc) documents.push(doc);
+    }
   }
 
   // 4.3 detailsInjections → EntityDetailsInjectionDocument(s)

--- a/src/utils/screenConversion.ts
+++ b/src/utils/screenConversion.ts
@@ -159,27 +159,28 @@ export function resolveTarget(
 }
 
 // ---------------------------------------------------------------------------
-// Base entity node types (entities without an OpenPipeline node)
+// Builtin entity node types (entities without an OpenPipeline node)
 // ---------------------------------------------------------------------------
 
 /**
- * Classic base-entity types that have no OpenPipeline Smartscape node definition, mapped to their
+ * Classic builtin entity types that have no OpenPipeline Smartscape node definition, mapped to
+ * their
  * platform node type. These entities cannot be derived from `smartscapeNodeExtraction`, so screens
  * keyed on them (typically injection-only) rely on this static lookup to resolve their node type.
- * Extend this record as more base entities need to be supported.
+ * Extend this record as more builtin entities need to be supported.
  */
-export const BASE_ENTITY_NODE_TYPES: Record<string, string> = {
+export const BUILTIN_ENTITY_NODE_TYPES: Record<string, string> = {
   HOST: "HOST",
   PROCESS_GROUP_INSTANCE: "PROCESS",
 };
 
 /**
- * Builds a NodeContext for a base entity type that has no OpenPipeline node. Base entities carry no
- * field map or static edges — only their platform node type is known. Returns undefined for entity
- * types that are not recognised base entities.
+ * Builds a NodeContext for a builtin entity type that has no OpenPipeline node. Builtin entities
+ * carry no field map or static edges — only their platform node type is known. Returns undefined
+ * for entity types that are not recognised builtin entities.
  */
-export function getBaseEntityNodeContext(entityType: string): NodeContext | undefined {
-  const nodeType = BASE_ENTITY_NODE_TYPES[entityType];
+export function getBuiltinEntityNodeContext(entityType: string): NodeContext | undefined {
+  const nodeType = BUILTIN_ENTITY_NODE_TYPES[entityType];
   if (!nodeType) return undefined;
   return { nodeType, fieldMap: {}, staticEdges: [] };
 }

--- a/src/utils/screenConversion.ts
+++ b/src/utils/screenConversion.ts
@@ -159,6 +159,32 @@ export function resolveTarget(
 }
 
 // ---------------------------------------------------------------------------
+// Base entity node types (entities without an OpenPipeline node)
+// ---------------------------------------------------------------------------
+
+/**
+ * Classic base-entity types that have no OpenPipeline Smartscape node definition, mapped to their
+ * platform node type. These entities cannot be derived from `smartscapeNodeExtraction`, so screens
+ * keyed on them (typically injection-only) rely on this static lookup to resolve their node type.
+ * Extend this record as more base entities need to be supported.
+ */
+export const BASE_ENTITY_NODE_TYPES: Record<string, string> = {
+  HOST: "HOST",
+  PROCESS_GROUP_INSTANCE: "PROCESS",
+};
+
+/**
+ * Builds a NodeContext for a base entity type that has no OpenPipeline node. Base entities carry no
+ * field map or static edges — only their platform node type is known. Returns undefined for entity
+ * types that are not recognised base entities.
+ */
+export function getBaseEntityNodeContext(entityType: string): NodeContext | undefined {
+  const nodeType = BASE_ENTITY_NODE_TYPES[entityType];
+  if (!nodeType) return undefined;
+  return { nodeType, fieldMap: {}, staticEdges: [] };
+}
+
+// ---------------------------------------------------------------------------
 // Charts card converter (chartsCards → chart-group)
 // ---------------------------------------------------------------------------
 

--- a/test/unit/__tests__/utils/screenConversion.test.ts
+++ b/test/unit/__tests__/utils/screenConversion.test.ts
@@ -30,7 +30,7 @@ import {
   addWarning,
   adjustAllDql,
   adjustEntityFetchDqlQuery,
-  BASE_ENTITY_NODE_TYPES,
+  BUILTIN_ENTITY_NODE_TYPES,
   convertChartsCard,
   convertConditions,
   convertDqlTableCard,
@@ -40,7 +40,7 @@ import {
   deduplicateSeriesFieldNames,
   extractCondition,
   generateConversionReport,
-  getBaseEntityNodeContext,
+  getBuiltinEntityNodeContext,
   parseDqlQuery,
   shouldSkipByTarget,
   splitDqlPipes,
@@ -1391,15 +1391,15 @@ describe("convertPropertiesCard — registry key adjustment", () => {
   });
 });
 
-describe("base entity node types", () => {
+describe("builtin entity node types", () => {
   it("seeds the lookup with HOST and PROCESS_GROUP_INSTANCE", () => {
-    expect(BASE_ENTITY_NODE_TYPES.HOST).toBe("HOST");
-    expect(BASE_ENTITY_NODE_TYPES.PROCESS_GROUP_INSTANCE).toBe("PROCESS");
+    expect(BUILTIN_ENTITY_NODE_TYPES.HOST).toBe("HOST");
+    expect(BUILTIN_ENTITY_NODE_TYPES.PROCESS_GROUP_INSTANCE).toBe("PROCESS");
   });
 
-  describe("getBaseEntityNodeContext", () => {
+  describe("getBuiltinEntityNodeContext", () => {
     it("builds a node context for HOST", () => {
-      expect(getBaseEntityNodeContext("HOST")).toEqual({
+      expect(getBuiltinEntityNodeContext("HOST")).toEqual({
         nodeType: "HOST",
         fieldMap: {},
         staticEdges: [],
@@ -1407,16 +1407,16 @@ describe("base entity node types", () => {
     });
 
     it("maps PROCESS_GROUP_INSTANCE to the PROCESS node type", () => {
-      expect(getBaseEntityNodeContext("PROCESS_GROUP_INSTANCE")).toEqual({
+      expect(getBuiltinEntityNodeContext("PROCESS_GROUP_INSTANCE")).toEqual({
         nodeType: "PROCESS",
         fieldMap: {},
         staticEdges: [],
       });
     });
 
-    it("returns undefined for entity types that are not recognised base entities", () => {
-      expect(getBaseEntityNodeContext("f5:pool:member")).toBeUndefined();
-      expect(getBaseEntityNodeContext("SERVICE")).toBeUndefined();
+    it("returns undefined for entity types that are not recognised builtin entities", () => {
+      expect(getBuiltinEntityNodeContext("f5:pool:member")).toBeUndefined();
+      expect(getBuiltinEntityNodeContext("SERVICE")).toBeUndefined();
     });
   });
 });

--- a/test/unit/__tests__/utils/screenConversion.test.ts
+++ b/test/unit/__tests__/utils/screenConversion.test.ts
@@ -30,6 +30,7 @@ import {
   addWarning,
   adjustAllDql,
   adjustEntityFetchDqlQuery,
+  BASE_ENTITY_NODE_TYPES,
   convertChartsCard,
   convertConditions,
   convertDqlTableCard,
@@ -39,6 +40,7 @@ import {
   deduplicateSeriesFieldNames,
   extractCondition,
   generateConversionReport,
+  getBaseEntityNodeContext,
   parseDqlQuery,
   shouldSkipByTarget,
   splitDqlPipes,
@@ -1386,5 +1388,35 @@ describe("convertPropertiesCard — registry key adjustment", () => {
     };
     const metadata = defined(convertPropertiesCard(card, "f5:pool:member", []));
     expect(metadata.overrideMetadataRegistry).toHaveProperty("cpu_usage");
+  });
+});
+
+describe("base entity node types", () => {
+  it("seeds the lookup with HOST and PROCESS_GROUP_INSTANCE", () => {
+    expect(BASE_ENTITY_NODE_TYPES.HOST).toBe("HOST");
+    expect(BASE_ENTITY_NODE_TYPES.PROCESS_GROUP_INSTANCE).toBe("PROCESS");
+  });
+
+  describe("getBaseEntityNodeContext", () => {
+    it("builds a node context for HOST", () => {
+      expect(getBaseEntityNodeContext("HOST")).toEqual({
+        nodeType: "HOST",
+        fieldMap: {},
+        staticEdges: [],
+      });
+    });
+
+    it("maps PROCESS_GROUP_INSTANCE to the PROCESS node type", () => {
+      expect(getBaseEntityNodeContext("PROCESS_GROUP_INSTANCE")).toEqual({
+        nodeType: "PROCESS",
+        fieldMap: {},
+        staticEdges: [],
+      });
+    });
+
+    it("returns undefined for entity types that are not recognised base entities", () => {
+      expect(getBaseEntityNodeContext("f5:pool:member")).toBeUndefined();
+      expect(getBaseEntityNodeContext("SERVICE")).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes VAST-749. The "Convert Screens" command silently dropped `detailsInjections` / `listInjections` defined on **base-entity screens** (`HOST`, `PROCESS_GROUP_INSTANCE`). Base entities have no OpenPipeline node, so they never entered `entityToNodeMap`, were filtered out of the convertible entity types, and their injection-only screens were never processed. Observed on the `python-tibcoems` extension.

This change resolves base-entity node types via a small, extensible static lookup and threads it through screen selection and conversion so base-entity injections are emitted with the correct `target.nodeType` / `target.invExType`.

## Self-review

### Key changes
- `src/utils/screenConversion.ts` — new exported `BASE_ENTITY_NODE_TYPES` (`HOST → "HOST"`, `PROCESS_GROUP_INSTANCE → "PROCESS"`; extensible) and `getBaseEntityNodeContext()` returning a `NodeContext` with empty field map / static edges.
- `src/commandPalette/convertScreens.ts`:
  - Selection: base-entity screens with injections are added to the convertible list and appear in the quick-pick alongside custom entities.
  - Per-screen loop: node context resolved as `entityToNodeMap[type] ?? getBaseEntityNodeContext(type)`; unresolved types are skipped with a warning.
  - `convertSingleScreen(..., isBaseEntity)`: for base entities only injections are converted; `detailsSettings` / `listSettings` are skipped with a `skipped-out-of-scope` warning (the extension does not own the base entity's screen definition).
- `test/unit/__tests__/utils/screenConversion.test.ts` — unit tests for the constant and helper.

### Risk areas / things to scrutinize
- **Node-type accuracy.** Injection documents are fetched at runtime by `target.nodeType`; a wrong value means the injection silently never renders. The seed values (`HOST → "HOST"`, `PROCESS_GROUP_INSTANCE → "PROCESS"`) were provided by the requester and should be confirmed against a live environment.
- Injection target node type falls back to `context.nodeType` (the base entity's platform node type) since base-entity screens have no top-level `entitySelectorTemplate` — relies on the existing fallback in `buildDetailsInjections` / `buildListInjections`.

### Test evidence
- Lint: `npm run pretest` (compile + `eslint src`) — pass.
- Tests: `npm run test:unit` — 514 passed, 22 suites.
- Smoke / manual verification: **recommended** — run "Convert Screens" against `python-tibcoems` and confirm `HOST` / `PROCESS_GROUP_INSTANCE` appear in the quick-pick and that `host-…-detailsinjection.screen.json` / `process-…-detailsinjection.screen.json` are written with `target.nodeType` `"HOST"` / `"PROCESS"`. Not runnable in this headless environment (VS Code command requiring a cached parsed extension).

### Spec checklist
- [x] Static extensible base-entity → node-type constant — `BASE_ENTITY_NODE_TYPES`
- [x] Include base-entity injection screens in convertible types / quick-pick
- [x] Build node context for base entities (node type, empty field map / static edges)
- [x] Base-entity conversion restricted to injections only (settings skipped with warning)
- [x] Unit tests per Testing Strategy
- [x] Live manual verification of node-type strings — deferred to reviewer (needs a live environment)

### Deviations & notes
- Scope kept to base-entity screens only (per refinement decision): injection targets derived from `entitySelectorTemplate=type(host)` on custom-entity screens are intentionally unchanged.
