### PR TITLE
VAST-768: sort workspaces tree view alphabetically

### DIFF
--- a/src/treeViews/workspacesTreeView.ts
+++ b/src/treeViews/workspacesTreeView.ts
@@ -50,6 +50,13 @@ export const refreshWorkspacesTreeView = () => {
 };
 
 /**
+ * Extracts the display text of a tree item's label, which may be a plain string
+ * or a {@link vscode.TreeItemLabel}. Used for alphabetical sorting.
+ */
+const labelText = (item: WorkspaceTreeItem): string =>
+  typeof item.label === "string" ? item.label : item.label?.label ?? "";
+
+/**
  * Creates a TreeItem that can be used to represent either an extensions workspace
  * or an extension manifest within that workspace.
  * @param label the label to be shown in the tree view (as node)
@@ -138,22 +145,29 @@ class WorkspacesTreeDataProviderImpl implements WorkspacesTreeDataProvider {
           ),
         );
       });
+      // Render extensions alphabetically (case-insensitive) by name
+      extensions.sort((a, b) =>
+        labelText(a).localeCompare(labelText(b), undefined, { sensitivity: "base" }),
+      );
       return extensions;
     }
-    // If not item specified, grab all workspaces from global storage
-    return getAllWorkspaces().map(workspace =>
-      createWorkspacesTreeItem(
-        workspace.name.toUpperCase(),
-        vscode.TreeItemCollapsibleState.Collapsed,
-        workspace.folder,
-        vscode.workspace.workspaceFolders &&
-          vscode.workspace.workspaceFolders[0].uri.toString() === workspace.folder
-          ? ICONS.EXTENSION_CURRENT
-          : ICONS.EXTENSION,
-        "extensionWorkspace",
-        workspace.id,
-      ),
-    );
+    // If no item specified, grab all workspaces from global storage, sorted
+    // alphabetically (case-insensitive) by their raw name - not the upper-cased label.
+    return [...getAllWorkspaces()]
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }))
+      .map(workspace =>
+        createWorkspacesTreeItem(
+          workspace.name.toUpperCase(),
+          vscode.TreeItemCollapsibleState.Collapsed,
+          workspace.folder,
+          vscode.workspace.workspaceFolders &&
+            vscode.workspace.workspaceFolders[0].uri.toString() === workspace.folder
+            ? ICONS.EXTENSION_CURRENT
+            : ICONS.EXTENSION,
+          "extensionWorkspace",
+          workspace.id,
+        ),
+      );
   }
 }
 

--- a/test/unit/__tests__/treeViews/workspacesTreeView.test.ts
+++ b/test/unit/__tests__/treeViews/workspacesTreeView.test.ts
@@ -1,0 +1,107 @@
+/**
+  Copyright 2022 Dynatrace LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { glob } from "glob";
+import { ExtensionWorkspaceDto } from "../../../../src/interfaces/treeViews";
+import { WorkspaceTreeItem } from "../../../../src/interfaces/treeViews";
+import * as fileSystem from "../../../../src/utils/fileSystem";
+import * as yamlParsing from "../../../../src/utils/yamlParsing";
+import { getWorkspacesTreeDataProvider } from "../../../../src/treeViews/workspacesTreeView";
+
+jest.mock("../../../../src/utils/logging");
+jest.mock("../../../../src/utils/fileSystem");
+jest.mock("../../../../src/utils/yamlParsing");
+jest.mock("glob", () => ({ glob: { sync: jest.fn() } }));
+jest.mock("fs", () => ({
+  ...jest.requireActual("fs"),
+  readFileSync: jest.fn().mockReturnValue(""),
+}));
+
+const mockGetAllWorkspaces = fileSystem.getAllWorkspaces as jest.MockedFunction<
+  typeof fileSystem.getAllWorkspaces
+>;
+const mockGlobSync = glob.sync as unknown as jest.Mock;
+const mockParseYAML = yamlParsing.parseYAML as unknown as jest.Mock;
+
+const buildWorkspace = (name: string): ExtensionWorkspaceDto => ({
+  name,
+  id: `id-${name}`,
+  folder: `/workspaces/${name}`,
+});
+
+const labelOf = (item: WorkspaceTreeItem) => String(item.label);
+
+describe("WorkspacesTreeDataProvider.getChildren()", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("root level (workspaces)", () => {
+    it("returns workspaces alphabetically sorted regardless of stored order", () => {
+      mockGetAllWorkspaces.mockReturnValue([
+        buildWorkspace("gamma"),
+        buildWorkspace("alpha"),
+        buildWorkspace("beta"),
+      ]);
+
+      const items = getWorkspacesTreeDataProvider().getChildren();
+
+      // Labels are upper-cased for display, but ordering is by the raw name.
+      expect(items.map(labelOf)).toEqual(["ALPHA", "BETA", "GAMMA"]);
+    });
+
+    it("sorts case-insensitively (mixed case)", () => {
+      mockGetAllWorkspaces.mockReturnValue([
+        buildWorkspace("Gamma"),
+        buildWorkspace("alpha"),
+        buildWorkspace("Beta"),
+      ]);
+
+      const items = getWorkspacesTreeDataProvider().getChildren();
+
+      expect(items.map(labelOf)).toEqual(["ALPHA", "BETA", "GAMMA"]);
+    });
+
+    it("does not mutate the array returned by getAllWorkspaces", () => {
+      const stored = [buildWorkspace("gamma"), buildWorkspace("alpha")];
+      mockGetAllWorkspaces.mockReturnValue(stored);
+
+      getWorkspacesTreeDataProvider().getChildren();
+
+      expect(stored.map(w => w.name)).toEqual(["gamma", "alpha"]);
+    });
+  });
+
+  describe("child level (extensions)", () => {
+    it("returns extensions alphabetically sorted by name", () => {
+      // First glob call (root extension), second glob call (nested extensions)
+      mockGlobSync.mockReturnValueOnce([]).mockReturnValueOnce([
+        "custom-a/extension/extension.yaml",
+        "custom-b/extension/extension.yaml",
+        "custom-c/extension/extension.yaml",
+      ]);
+      mockParseYAML
+        .mockReturnValueOnce({ name: "zeta", version: "1.0.0" })
+        .mockReturnValueOnce({ name: "alpha", version: "1.0.0" })
+        .mockReturnValueOnce({ name: "mu", version: "1.0.0" });
+
+      const element = { path: { fsPath: "/workspaces/ws" } } as unknown as WorkspaceTreeItem;
+      const items = getWorkspacesTreeDataProvider().getChildren(element);
+
+      expect(items.map(labelOf)).toEqual(["alpha", "mu", "zeta"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **VAST-768** (Workspace tree view sorting). The **Extension 2.0 Workspaces** tree view (`dynatrace-extensions-workspaces`) previously rendered workspaces in insertion order, making a long list hard to scan. Workspace nodes and their extension children are now rendered alphabetically (case-insensitive).

Per the refined Technical specification, the search/filter capability was **descoped** (no native VS Code search-bar API exists for custom tree views); this PR delivers the sorting requirement only.

## Self-review

### Key changes
- `src/treeViews/workspacesTreeView.ts` — in `WorkspacesTreeDataProviderImpl.getChildren()`:
  - Root level: sort a copy of `getAllWorkspaces()` by raw `name` (case-insensitive `localeCompare`, `sensitivity: "base"`) before mapping to tree items. Sorts on the raw name, not the upper-cased display label.
  - Child level: sort extension items alphabetically by name before returning.
  - Added a small `labelText()` helper to safely read a tree item's label (`string | vscode.TreeItemLabel`) for sorting.
- `test/unit/__tests__/treeViews/workspacesTreeView.test.ts` — new unit test suite.

### Risk areas / things to scrutinize
- `getAllWorkspaces()` is left untouched; sorting uses a copied array (`[...]`) so persisted storage/order and other callers (`findWorkspace`, workspace counts) are unaffected.
- Sorting is case-insensitive/locale-aware. If a strict locale-independent order is ever required, the comparator is the single place to change.

### Test evidence
- Lint: `npm run pretest` (compile + eslint) — pass, 0 problems.
- Tests: `npm run test:unit` — **518 passed, 23 suites**, including 4 new tests (root sort, case-insensitive sort, no-mutation of source array, child extension sort).
- Smoke: unit tests exercise `getChildren()` for both levels directly.

### Spec checklist
- [x] Sort root workspaces alphabetically — `workspacesTreeView.ts` root branch.
- [x] Sort extension children alphabetically — `workspacesTreeView.ts` child branch.
- [x] Verify rendering — covered by unit tests for both levels.

### Deviations & notes
- Added a `labelText()` helper (not explicitly in the spec) to satisfy the `@typescript-eslint/no-base-to-string` rule when sorting on the union-typed `label`. Mirrors the existing label-extraction pattern in `src/treeViews/commands/workspaces.ts`.
- Search/filter intentionally out of scope per the refined spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
