### PR TITLE
#323 - Suggest EXT_ prefix by default for custom extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ graphify-out
 .claude/settings*
 .claude/commands/jira-refine.md
 .claude/commands/jira-deliver.md
+.venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Version 3.0.2 (06.08.2026)
+
+### 🪲 Fixed in this version
+
+- [Smartscape v2 extraction: suggest the required `EXT_` prefix for custom extension node types](https://github.com/dynatrace-extensions/dynatrace-extensions-vscode/issues/323)
+
+---
+
 ## Version 3.0.1 (28.07.2026)
 
 ### 🪲 Fixed in this version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynatrace-extensions",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dynatrace-extensions",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dependencies": {
         "@dynatrace-internal/client-extensions": "^0.8.0",
         "@dynatrace-sdk/client-credential-vault": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "extensions@dynatrace.com",
     "url": "https://info.dynatrace.com/global_all_wp_dynatrace_services_platform_extensions_fact_sheet_13656_fulfillment.html"
   },
-  "version": "3.0.1",
+  "version": "3.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/dynatrace-extensions/dynatrace-extensions-vscode.git"

--- a/src/commandPalette/convertTopology.ts
+++ b/src/commandPalette/convertTopology.ts
@@ -26,12 +26,19 @@ import {
   OpenPipeline,
 } from "../interfaces/extensionMeta";
 import { getCachedParsedExtension } from "../utils/caching";
+import { checkDtInternalProperties } from "../utils/conditionCheckers";
 import { updateYamlNode } from "../utils/dashboards";
 import { getExtensionFilePath } from "../utils/fileSystem";
 import logger from "../utils/logging";
 
 // Fields that are not allowed to be extracted in OpenPipeline
 const BLOCKED_FIELDS = ["dt.security_context"];
+
+// Smartscape node types must start with one of these prefixes. Custom (external)
+// extensions must use "EXT_"; internal Dynatrace extensions register their own
+// node types and must not carry a prefix.
+const EXTERNAL_NODE_TYPE_PREFIX = "EXT_";
+const NODE_TYPE_PREFIXES = ["EXT_", "CUSTOM_"];
 
 // OpenPipeline file names
 const METRIC_PIPELINE_FILE = "metrics.pipeline.json";
@@ -94,10 +101,16 @@ export async function createSmartscapeTopologyWorkflow() {
 
   const inputCallback = inputModeChoice.value === "auto" ? autoInputCallback : vscodeInputCallback;
 
+  // External (custom) extensions require the "EXT_" prefix on node types, while
+  // internal Dynatrace extensions must not carry it.
+  const isInternal = await checkDtInternalProperties();
+  const typePrefix = isInternal ? "" : EXTERNAL_NODE_TYPE_PREFIX;
+
   try {
     const { pipelineExtensionYaml, pipelineDocs } = await convertTopologyToOpenPipeline(
       extension,
       inputCallback,
+      typePrefix,
     );
 
     const files: string[] = [];
@@ -153,6 +166,7 @@ const cleanExtensionName = (extensionName: string): string => {
 export const convertTopologyToOpenPipeline = async (
   extension: ExtensionStub,
   inputCallback: InputCallback,
+  typePrefix: string = EXTERNAL_NODE_TYPE_PREFIX,
 ): Promise<{
   pipelineExtensionYaml: OpenPipeline;
   pipelineDocs: OpenPipelineDocs;
@@ -176,6 +190,7 @@ export const convertTopologyToOpenPipeline = async (
       extension.metrics,
       inputCallback,
       typeNameMapping,
+      typePrefix,
     );
     metricsNodeProcessors = result.metricsProcessors;
     logsNodeProcessors = result.logsProcessors;
@@ -187,6 +202,7 @@ export const convertTopologyToOpenPipeline = async (
       extension.topology.relationships,
       typeNameMapping,
       inputCallback,
+      typePrefix,
     );
     metricsEdgeProcessors = edgeResult.metricsProcessors;
     logsEdgeProcessors = edgeResult.logsProcessors;
@@ -310,6 +326,7 @@ export const createProcessorsFromRelationships = async (
   }>,
   typeNameMapping: Map<string, string>,
   inputCallback: InputCallback,
+  typePrefix: string = EXTERNAL_NODE_TYPE_PREFIX,
 ): Promise<{
   metricsProcessors: OpenPipelineProcessor[];
   logsProcessors: OpenPipelineProcessor[];
@@ -325,7 +342,7 @@ export const createProcessorsFromRelationships = async (
     if (!fromTypeName) {
       const userInput = await inputCallback(
         `Enter new name for source type "${relationship.fromType}"`,
-        suggestNewTypeName(relationship.fromType),
+        suggestNewTypeName(relationship.fromType, typePrefix),
       );
       if (!userInput) {
         throw Error("User cancelled the operation");
@@ -338,7 +355,7 @@ export const createProcessorsFromRelationships = async (
     if (!toTypeName) {
       const userInput = await inputCallback(
         `Enter new name for target type "${relationship.toType}"`,
-        suggestNewTypeName(relationship.toType),
+        suggestNewTypeName(relationship.toType, typePrefix),
       );
       if (!userInput) {
         throw Error("User cancelled the operation");
@@ -517,6 +534,7 @@ export const createProcessorsFromTopology = async (
   metrics: MetricMetadata[] | undefined,
   inputCallback: InputCallback,
   typeNameMapping?: Map<string, string>,
+  typePrefix: string = EXTERNAL_NODE_TYPE_PREFIX,
 ): Promise<{
   metricsProcessors: OpenPipelineProcessor[];
   logsProcessors: OpenPipelineProcessor[];
@@ -532,7 +550,7 @@ export const createProcessorsFromTopology = async (
   // while asking the user for input when necessary
   for (const type of types) {
     // Show a input for the user to select the new name
-    const suggestedName = suggestNewTypeName(type.name);
+    const suggestedName = suggestNewTypeName(type.name, typePrefix);
     const newName = await inputCallback(`Enter new name for type "${type.name}"`, suggestedName);
 
     if (!newName) {
@@ -726,10 +744,21 @@ const processLogsSource = async (
   return processors;
 };
 
-const suggestNewTypeName = (currentName: string): string => {
+const suggestNewTypeName = (
+  currentName: string,
+  typePrefix: string = EXTERNAL_NODE_TYPE_PREFIX,
+): string => {
   // Entities names should be uppercase and separated by '_'
   // Example: cloudhub:org becomes CLOUDHUB_ORG, cloud-application becomes CLOUD_APPLICATION
-  return currentName.toUpperCase().replace(/[:-]/g, "_");
+  const normalizedName = currentName.toUpperCase().replace(/[:-]/g, "_");
+
+  // Smartscape node types must start with "EXT_" or "CUSTOM_". Apply the prefix for
+  // external extensions, but don't double-prefix a name that already carries one.
+  if (!typePrefix || NODE_TYPE_PREFIXES.some(prefix => normalizedName.startsWith(prefix))) {
+    return normalizedName;
+  }
+
+  return `${typePrefix}${normalizedName}`;
 };
 
 /**

--- a/test/unit/__tests__/commandPalette/convertTopology.test.ts
+++ b/test/unit/__tests__/commandPalette/convertTopology.test.ts
@@ -103,9 +103,10 @@ describe("convertTopology", () => {
       const nodeTypes = processors.map((p: OpenPipelineProcessor) => p.smartscapeNode?.nodeType);
       const uniqueNodeTypes = [...new Set(nodeTypes.filter((t): t is string => !!t))];
 
-      expect(uniqueNodeTypes).toContain("CLOUDHUB_ORG");
-      expect(uniqueNodeTypes).toContain("CLOUDHUB_ENV");
-      expect(uniqueNodeTypes).toContain("CLOUDHUB_APP");
+      // External extensions get the required "EXT_" prefix by default
+      expect(uniqueNodeTypes).toContain("EXT_CLOUDHUB_ORG");
+      expect(uniqueNodeTypes).toContain("EXT_CLOUDHUB_ENV");
+      expect(uniqueNodeTypes).toContain("EXT_CLOUDHUB_APP");
     });
 
     it("should replace hyphens with underscores in suggested type names", async () => {
@@ -135,7 +136,66 @@ describe("convertTopology", () => {
       metricsProcessors.forEach(processor => {
         const nodeType = processor.smartscapeNode?.nodeType;
         expect(nodeType).not.toContain("-");
-        expect(nodeType).toBe("DT.ENTITY.CLOUD_APPLICATION");
+        expect(nodeType).toBe("EXT_DT.ENTITY.CLOUD_APPLICATION");
+      });
+    });
+
+    it("should not add the EXT_ prefix for internal extensions", async () => {
+      const types: TopologyType[] = [
+        {
+          name: "cloud-application",
+          displayName: "Cloud Application",
+          rules: [
+            {
+              idPattern: "app_{app.id}",
+              instanceNamePattern: "{app.name}",
+              sources: [{ sourceType: "Metrics", condition: "$prefix(cloud.app)" }],
+              attributes: [],
+            },
+          ],
+        },
+      ];
+
+      // Internal extensions pass an empty prefix
+      const { metricsProcessors } = await createProcessorsFromTopology(
+        types,
+        [{ key: "cloud.app.cpu", metadata: { displayName: "CPU" } }],
+        autoInputCallback,
+        undefined,
+        "",
+      );
+
+      expect(metricsProcessors.length).toBeGreaterThan(0);
+      metricsProcessors.forEach(processor => {
+        expect(processor.smartscapeNode?.nodeType).toBe("CLOUD_APPLICATION");
+      });
+    });
+
+    it("should not double-prefix names that already start with a valid prefix", async () => {
+      const types: TopologyType[] = [
+        {
+          name: "EXT_already-prefixed",
+          displayName: "Already Prefixed",
+          rules: [
+            {
+              idPattern: "app_{app.id}",
+              instanceNamePattern: "{app.name}",
+              sources: [{ sourceType: "Metrics", condition: "$prefix(cloud.app)" }],
+              attributes: [],
+            },
+          ],
+        },
+      ];
+
+      const { metricsProcessors } = await createProcessorsFromTopology(
+        types,
+        [{ key: "cloud.app.cpu", metadata: { displayName: "CPU" } }],
+        autoInputCallback,
+      );
+
+      expect(metricsProcessors.length).toBeGreaterThan(0);
+      metricsProcessors.forEach(processor => {
+        expect(processor.smartscapeNode?.nodeType).toBe("EXT_ALREADY_PREFIXED");
       });
     });
 


### PR DESCRIPTION
We now suggest `EXT_` as the prefix when suggesting new node type names.

We check for internal extensions and do not suggest that prefix in that case